### PR TITLE
Allow CLI transport to be selected and not require an access token

### DIFF
--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -66,6 +66,12 @@ export default class AbstractAPI implements AbstractInterface {
     apiUrl = "https://api.goabstract.com",
     previewsUrl = "https://previews.goabstract.com"
   }: Options = {}) {
+    if (!accessToken) {
+      throw new Error(
+        "options.accessToken or ABSTRACT_TOKEN set as an environment variable is required"
+      );
+    }
+
     this.accessToken = accessToken;
     this.apiUrl = apiUrl;
     this.previewsUrl = previewsUrl;

--- a/src/Client/index.js
+++ b/src/Client/index.js
@@ -17,12 +17,6 @@ export default function Client({
   previewsUrl,
   transport: Transport = AUTO
 }: Options = {}): AbstractInterface {
-  if (!accessToken) {
-    throw new Error(
-      "options.accessToken or ABSTRACT_TOKEN set as an environment variable is required"
-    );
-  }
-
   if (!Transport) {
     throw new Error("options.transport is required");
   }


### PR DESCRIPTION
Local use should not require an access token.

Note: Because AUTO instantiates both transports it still acts as required there.