### PR TITLE
API: Support activities.info and notifications.info

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -36,6 +36,18 @@ abstract.activities.list({
 }, { limit: 2 });
 ```
 
+### Retrieve an activity
+
+`activities.info(ActivityDescriptor): Promise<Activity>`
+
+Load the info for an activity
+
+```js
+abstract.activities.info({
+  activityId: "616daa90-1736-11e8-b8b0-8d1fec7aef78"
+});
+```
+
 ## Branches
 
 ![API][api-icon]
@@ -521,6 +533,18 @@ abstract.notifications.list({
 }, { limit: 2 });
 ```
 
+### Retrieve a notification
+
+`notifications.info(NotificationDescriptor): Promise<Notification>`
+
+Load the info for a notification
+
+```js
+abstract.notifications.info({
+  notificationId: "616daa90-1736-11e8-b8b0-8d1fec7aef78"
+});
+```
+
 
 ## Organizations
 
@@ -803,5 +827,13 @@ Reference for the parameters required to load resources with Abstract SDK.
 ```js
 {
   activityId: string
+}
+```
+
+### NotificationDescriptor
+
+```js
+{
+  notificationId: string
 }
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -797,3 +797,11 @@ Reference for the parameters required to load resources with Abstract SDK.
   collectionId: string
 }
 ```
+
+### ActivityDescriptor
+
+```js
+{
+  activityId: string
+}
+```

--- a/src/AbstractAPI/__snapshots__/test.js.snap
+++ b/src/AbstractAPI/__snapshots__/test.js.snap
@@ -626,6 +626,26 @@ Object {
 }
 `;
 
+exports[`AbstractAPI with mocked global.fetch notifications.info({"notificationId": "notification-id"}) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/notifications/notification-id",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": "7",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+  ],
+}
+`;
+
 exports[`AbstractAPI with mocked global.fetch notifications.list({"organizationId": "organization-id"}) 1`] = `
 Object {
   "fetch": Array [

--- a/src/AbstractAPI/__snapshots__/test.js.snap
+++ b/src/AbstractAPI/__snapshots__/test.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AbstractAPI with mocked global.fetch activities.info({"activityId": "activity-id"}) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/activities/activity-id",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": "7",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+  ],
+}
+`;
+
 exports[`AbstractAPI with mocked global.fetch activities.list({"branchId": "branch-id", "projectId": "project-id"}) 1`] = `
 Object {
   "fetch": Array [

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -21,6 +21,7 @@ import type {
   FileDescriptor,
   LayerDescriptor,
   CollectionDescriptor,
+  ActivityDescriptor,
   Comment,
   Layer,
   ListOptions
@@ -156,6 +157,10 @@ export default class AbstractAPI implements AbstractInterface {
       const response = await this.fetch(`activities?${query}`);
       const { activities } = await unwrapEnvelope(response.json());
       return activities;
+    },
+    info: async ({ activityId }: ActivityDescriptor) => {
+      const response = await this.fetch(`activities/${activityId}`);
+      return response.json();
     }
   };
 

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -22,6 +22,7 @@ import type {
   LayerDescriptor,
   CollectionDescriptor,
   ActivityDescriptor,
+  NotificationDescriptor,
   Comment,
   Layer,
   ListOptions
@@ -457,6 +458,10 @@ export default class AbstractAPI implements AbstractInterface {
       const response = await this.fetch(`notifications?${query}`);
       const notifications = await unwrapEnvelope(response.json());
       return notifications;
+    },
+    info: async ({ notificationId }: NotificationDescriptor) => {
+      const response = await this.fetch(`notifications/${notificationId}`);
+      return response.json();
     }
   };
 

--- a/src/AbstractAPI/test.js
+++ b/src/AbstractAPI/test.js
@@ -11,7 +11,8 @@ import {
   buildBranchDescriptor,
   buildFileDescriptor,
   buildLayerDescriptor,
-  buildCollectionDescriptor
+  buildCollectionDescriptor,
+  buildActivityDescriptor
 } from "../support/factories";
 import AbstractAPI from "./";
 
@@ -32,7 +33,8 @@ const responses = {
         }
       }),
       { status: 200 }
-    ]
+    ],
+    info: () => [JSON.stringify({ id: "foo" })]
   },
   collections: {
     list: () => [
@@ -123,6 +125,11 @@ describe("AbstractAPI", () => {
         "activities.list",
         buildProjectDescriptor(),
         { responses: [responses.activities.list()] }
+      ],
+      [
+        "activities.info",
+        buildActivityDescriptor(),
+        { responses: [responses.activities.info()] }
       ],
       // organizations
       ["organizations.list", undefined],

--- a/src/AbstractAPI/test.js
+++ b/src/AbstractAPI/test.js
@@ -12,7 +12,8 @@ import {
   buildFileDescriptor,
   buildLayerDescriptor,
   buildCollectionDescriptor,
-  buildActivityDescriptor
+  buildActivityDescriptor,
+  buildNotificationDescriptor
 } from "../support/factories";
 import AbstractAPI from "./";
 
@@ -34,7 +35,7 @@ const responses = {
       }),
       { status: 200 }
     ],
-    info: () => [JSON.stringify({ id: "foo" })]
+    info: () => [JSON.stringify({ id: "foo" }), { status: 200 }]
   },
   collections: {
     list: () => [
@@ -99,7 +100,8 @@ const responses = {
         data: [{ id: "foo" }, { id: "bar" }]
       }),
       { status: 200 }
-    ]
+    ],
+    info: () => [JSON.stringify({ id: "foo" }), { status: 200 }]
   }
 };
 
@@ -268,6 +270,11 @@ describe("AbstractAPI", () => {
         "notifications.list",
         buildOrganizationDescriptor(),
         { responses: [responses.notifications.list()] }
+      ],
+      [
+        "notifications.info",
+        buildNotificationDescriptor(),
+        { responses: [responses.notifications.info()] }
       ]
     ])("%s(%p)", async (property, args, options = {}) => {
       args = Array.isArray(args) ? args : [args];

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -12,6 +12,10 @@ export type ActivityDescriptor = {|
   activityId: string
 |};
 
+export type NotificationDescriptor = {|
+  notificationId: string
+|}
+
 type ObjectDescriptor = {|
   projectId: string,
   sha?: string, // undefined is "latest"
@@ -1269,6 +1273,7 @@ export interface AbstractInterface {
     list: (
       objectDescriptor?: OrganizationDescriptor,
       options?: ListOptions
-    ) => Promise<Notification[]>
+    ) => Promise<Notification[]>,
+    info: (notificationDescriptor: NotificationDescriptor) => Promise<Notification>
   };
 }

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -8,6 +8,10 @@ export type ProjectDescriptor = {|
   projectId: string
 |};
 
+export type ActivityDescriptor = {|
+  activityId: string
+|};
+
 type ObjectDescriptor = {|
   projectId: string,
   sha?: string, // undefined is "latest"
@@ -1185,7 +1189,8 @@ export interface AbstractInterface {
     list: (
       objectDescriptor?: BranchDescriptor | OrganizationDescriptor | ProjectDescriptor,
       options?: ListOptions
-    ) => Promise<Activity[]>
+    ) => Promise<Activity[]>,
+    info: (activityDescriptor: ActivityDescriptor) => Promise<Activity>
   };
 
   organizations?: {

--- a/src/support/factories.js
+++ b/src/support/factories.js
@@ -90,3 +90,10 @@ export function buildCollectionDescriptor(
     ...collectionDescriptor
   };
 }
+
+export function buildActivityDescriptor(activityDescriptor: *) {
+  return {
+    activityId: "activity-id",
+    ...activityDescriptor
+  };
+}

--- a/src/support/factories.js
+++ b/src/support/factories.js
@@ -97,3 +97,10 @@ export function buildActivityDescriptor(activityDescriptor: *) {
     ...activityDescriptor
   };
 }
+
+export function buildNotificationDescriptor(notificationDescriptor: *) {
+  return {
+    notificationId: "notification-id",
+    ...notificationDescriptor
+  };
+}


### PR DESCRIPTION
This pull request adds support for `activities.info` and `notifications.info`.

**Note:** This depends on goabstract/projects#915.

Resolves #20
Resolves #21