### PR TITLE
API: comments.list and comments.info

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -200,8 +200,11 @@ or, list the first two comments for a specific layer...
 
 ```js
 abstract.comments.list({
-  layerId: '9FB27CF4-81F5-40A3-AB34-B2E5C792BEE3',
-  projectId: '616daa90-1736-11e8-b8b0-8d1fec7aef78'
+  branchId: "master",
+  fileId: "51DE7CD1-ECDC-473C-B30E-62AE913743B7",
+  layerId: "CA420E64-08D0-4B96-B0F7-75AA316B6A19",
+  pageId: "7D2D2599-9B3F-49BC-9F86-9D9D532F143A",
+  projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78"
 }, { limit: 2 });
 ```
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -187,11 +187,35 @@ represents a bounding area ontop of the layer, this can be used to leave comment
 
 ### List all comments
 
-  > Not yet implemented
+`comments.list(BranchDescriptor | CommitDescriptor | PageDescriptor | LayerDescriptor): Promise<Comment[]>`
+
+List the comments for a specific project
+```js
+abstract.comments.list({
+  projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78"
+});
+```
+
+or, list the first two comments for a specific layer...
+
+```js
+abstract.comments.list({
+  layerId: '9FB27CF4-81F5-40A3-AB34-B2E5C792BEE3',
+  projectId: '616daa90-1736-11e8-b8b0-8d1fec7aef78'
+}, { limit: 2 });
+```
 
 ### Retrieve a comment
 
-  > Not yet implemented
+`comments.info(CommentDescriptor): Promise<Comment>`
+
+Load the info for a comment
+
+```js
+abstract.comments.info({
+  commentId: "616daa90-1736-11e8-b8b0-8d1fec7aef78"
+});
+```
 
 ### Create a comment
 
@@ -828,4 +852,11 @@ Reference for the parameters required to load resources with Abstract SDK.
 
 ```js
 { notificationId: string }
+```
+
+### CommentDescriptor
+ ```js
+{
+  commentId: string
+}
 ```

--- a/src/AbstractAPI/__snapshots__/test.js.snap
+++ b/src/AbstractAPI/__snapshots__/test.js.snap
@@ -386,6 +386,46 @@ Object {
 }
 `;
 
+exports[`AbstractAPI with mocked global.fetch comments.info({"commentId": "comment-id"}) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/comments/comment-id",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": "7",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+  ],
+}
+`;
+
+exports[`AbstractAPI with mocked global.fetch comments.list({"projectId": "project-id"}) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/comments?projectId=project-id",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": "7",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+  ],
+}
+`;
+
 exports[`AbstractAPI with mocked global.fetch commits.info({"branchId": "branch-id", "fileId": "file-id", "layerId": "layer-id", "pageId": "page-id", "projectId": "project-id", "sha": "commit-sha"}) 1`] = `
 Object {
   "fetch": Array [

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -23,6 +23,7 @@ import type {
   CollectionDescriptor,
   ActivityDescriptor,
   NotificationDescriptor,
+  CommentDescriptor,
   Comment,
   Layer,
   ListOptions
@@ -235,6 +236,32 @@ export default class AbstractAPI implements AbstractInterface {
         }
       );
 
+      return response.json();
+    },
+    list: async (
+      objectDescriptor: {
+        projectId: $PropertyType<ProjectDescriptor, "projectId">
+      } & $Shape<
+        BranchDescriptor & CommitDescriptor & PageDescriptor & LayerDescriptor
+      >,
+      options: ListOptions = {}
+    ) => {
+      const query = queryString.stringify({
+        limit: options.offset,
+        offset: options.offset,
+        branchId: objectDescriptor.branchId,
+        commitSha: objectDescriptor.sha,
+        fileId: objectDescriptor.fileId,
+        layerId: objectDescriptor.layerId,
+        pageId: objectDescriptor.pageId,
+        projectId: objectDescriptor.projectId
+      });
+      const response = await this.fetch(`comments?${query}`);
+      const comments = await unwrapEnvelope(response.json());
+      return comments;
+    },
+    info: async ({ commentId }: CommentDescriptor) => {
+      const response = await this.fetch(`comments/${commentId}`);
       return response.json();
     }
   };

--- a/src/AbstractAPI/test.js
+++ b/src/AbstractAPI/test.js
@@ -13,7 +13,8 @@ import {
   buildLayerDescriptor,
   buildCollectionDescriptor,
   buildActivityDescriptor,
-  buildNotificationDescriptor
+  buildNotificationDescriptor,
+  buildCommentDescriptor
 } from "../support/factories";
 import AbstractAPI from "./";
 
@@ -95,6 +96,15 @@ const responses = {
     ) => [data, { status: 200 }]
   },
   notifications: {
+    list: () => [
+      JSON.stringify({
+        data: [{ id: "foo" }, { id: "bar" }]
+      }),
+      { status: 200 }
+    ],
+    info: () => [JSON.stringify({ id: "foo" }), { status: 200 }]
+  },
+  comments: {
     list: () => [
       JSON.stringify({
         data: [{ id: "foo" }, { id: "bar" }]
@@ -186,6 +196,16 @@ describe("AbstractAPI", () => {
           { body: "Comment on branch at my-sha" }
         ],
         { responses: [responses.branches.info()] }
+      ],
+      [
+        "comments.list",
+        buildProjectDescriptor(),
+        { responses: [responses.comments.list()] }
+      ],
+      [
+        "comments.info",
+        buildCommentDescriptor(),
+        { responses: [responses.comments.info()] }
       ],
       // commits
       ["commits.list", buildBranchDescriptor()],

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -58,6 +58,10 @@ export type LayerDescriptor = {|
   layerId: string
 |};
 
+export type CommentDescriptor = {|
+  commentId: string
+|};
+
 export type Cursor<T> = Promise<{
   value: T,
   done: boolean
@@ -1221,7 +1225,14 @@ export interface AbstractInterface {
     create: (
       BranchDescriptor | LayerDescriptor,
       comment: Comment
-    ) => Promise<Comment>
+    ) => Promise<Comment>,
+    list: (
+      {
+        projectId: $PropertyType<ProjectDescriptor, "projectId">
+      } & $Shape<BranchDescriptor & CommitDescriptor & PageDescriptor & LayerDescriptor>,
+      options?: ListOptions
+    ) => Promise<Comment[]>,
+    info: (commentDescriptor: CommentDescriptor) => Promise<Comment>
   };
 
   commits: {

--- a/src/support/factories.js
+++ b/src/support/factories.js
@@ -6,7 +6,8 @@ import type {
   FileDescriptor,
   PageDescriptor,
   LayerDescriptor,
-  CollectionDescriptor
+  CollectionDescriptor,
+  CommentDescriptor
 } from "../";
 
 export function buildOptions(options: *) {
@@ -102,5 +103,14 @@ export function buildNotificationDescriptor(notificationDescriptor: *) {
   return {
     notificationId: "notification-id",
     ...notificationDescriptor
+  };
+}
+
+export function buildCommentDescriptor(
+  commentDescriptor: *
+): CommentDescriptor {
+  return {
+    commentId: "comment-id",
+    ...commentDescriptor
   };
 }


### PR DESCRIPTION
This pull request adds support for `comments.list` and `comments.info` to the API transport.

Resolves #30 