### PR TITLE
API: Render descriptors with one property on a single line

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -744,17 +744,13 @@ Reference for the parameters required to load resources with Abstract SDK.
 ### OrganizationDescriptor
 
 ```js
-{
-  organizationId: string,
-}
+{ organizationId: string }
 ```
 
 ### ProjectDescriptor
 
 ```js
-{
-  projectId: string,
-}
+{ projectId: string }
 ```
 
 ### BranchDescriptor
@@ -825,15 +821,11 @@ Reference for the parameters required to load resources with Abstract SDK.
 ### ActivityDescriptor
 
 ```js
-{
-  activityId: string
-}
+{ activityId: string }
 ```
 
 ### NotificationDescriptor
 
 ```js
-{
-  notificationId: string
-}
+{ notificationId: string }
 ```


### PR DESCRIPTION
This pull request updates the documentation for descriptor types with one property to be on a single line to save vertical space.