### PR TITLE
feature: add cursor-based pagination support

### DIFF
--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -20,17 +20,24 @@ The following example demonstrates how to work with pages of results.
 1. Use an SDK client instance to fetch the first ten activities for a project.
 
   ```js
-  const page = abstract.activities.list({
+  const firstPage = abstract.activities.list({
     projectId: 'b8bf5540-6e1e-11e6-8526-2d315b6ef48f'
   }, { limit: 10 });
   ```
 
-2. Since `page` is a `CursorPromise`, it will resolve to the first ten activities. Its `next` method can be used to fetch the next page of activities.
+2. Since `firstPage` is a `CursorPromise`, it will resolve to the first ten activities. Its `next` method can be used to fetch the next page of activities.
 
   ```js
-  console.log(`Result page: ${(await page).length} items`);
-  const nextPage = response.next();
-  console.log(`Result page: ${(await nextPage).length} items`);
+  const firstPage = abstract.activities.list({
+    projectId: 'b8bf5540-6e1e-11e6-8526-2d315b6ef48f'
+  }, { limit: 10 });
+
+  const firstPageResponse = await firstPage;
+
+  const secondPage = firstPage.next();
+  const secondPageResponse = await secondPage;
+
+  console.log(`First Page: ${firstPageResponse.length}, Second Page: ${secondPageResponse.length}`);
   ```
 
 3. Putting this all together, all activities could be fetched using recursion.

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -3,4 +3,47 @@ id: pagination
 title: Pagination
 ---
 
-Coming soon...
+Some SDK methods return large result sets that can be difficult to work with because of how many items they contain. To make working with such large sets easier and more efficient, these methods return a few items at a time in smaller sets called "pages".
+
+This section explains how to use these pages of results within the SDK.
+
+## Cursor pagination
+
+Instead of returning all results at once, paginated SDK methods return a **cursor** object. A cursor object contains a small portion of results - or a page - along with a function that can be called to fetch additional pages. Instead of manually managing options like `offset`, a cursor can be used to iteratively and automatically move through pages of results.
+
+In practice, paginated methods return a special type of `Promise` that contains a `next` method. This special `Promise` - called a `CursorPromise` - resolves to the current page of results. Its `next` method returns another `CursorPromise` that resolves to the next page of results, or `undefined` if none exist.
+
+## Example
+
+The following example demonstrates how to work with pages of results.
+
+1. Use an SDK client instance to fetch the first ten activities for a project.
+
+  ```js
+  const page = abstract.activities.list({
+    projectId: 'b8bf5540-6e1e-11e6-8526-2d315b6ef48f'
+  }, { limit: 10 });
+  ```
+
+2. Since `page` is a `CursorPromise`, it will resolve to the first ten activities. Its `next` method can be used to fetch the next page of activities.
+
+  ```js
+  console.log(`Result page: ${(await page).length} items`);
+  const nextPage = response.next();
+  console.log(`Result page: ${(await nextPage).length} items`);
+  ```
+
+3. Putting this all together, all activities could be fetched using recursion.
+
+  ```js
+  async function fetchActivities(request) {
+      const response = await request;
+      if (!response) return;
+      console.log(`Result page: ${response.length} items`);
+      fetchActivities(request.next());
+  }
+
+  fetchActivities(abstract.activities.list({
+    projectId: 'b8bf5540-6e1e-11e6-8526-2d315b6ef48f'
+  }, { limit: 10 }));
+  ```

--- a/src/AbstractAPI/Cursor.js
+++ b/src/AbstractAPI/Cursor.js
@@ -6,10 +6,6 @@ export default class Cursor<T> {
   meta: CursorMeta;
   request: (meta?: CursorMeta) => Promise<CursorResponse<T>>;
 
-  get promise(): CursorPromise<T> {
-    return ((this: any): CursorPromise<T>);
-  }
-
   _next(first?: boolean): CursorPromise<T> {
     const makeRequest = async () => {
       if (!first && !this.meta.nextOffset) return;
@@ -28,8 +24,11 @@ export default class Cursor<T> {
     return cursorPromise;
   }
 
-  constructor(request: (meta?: CursorMeta) => Promise<CursorResponse<T>>) {
+  constructor(
+    request: (meta?: CursorMeta) => Promise<CursorResponse<T>>
+  ): CursorPromise<T> {
     this.request = request;
+    return ((this: any): CursorPromise<T>);
   }
 
   then(
@@ -41,7 +40,7 @@ export default class Cursor<T> {
     return cursorPromise;
   }
 
-  next(first?: boolean): CursorPromise<T> {
+  next(): CursorPromise<T> {
     return this._next();
   }
 }

--- a/src/AbstractAPI/Cursor.js
+++ b/src/AbstractAPI/Cursor.js
@@ -6,6 +6,13 @@ export default class Cursor<T> {
   meta: CursorMeta;
   request: (meta?: CursorMeta) => Promise<CursorResponse<T>>;
 
+  constructor(
+    request: (meta?: CursorMeta) => Promise<CursorResponse<T>>
+  ): CursorPromise<T> {
+    this.request = request;
+    return ((this: any): CursorPromise<T>);
+  }
+
   _next(first?: boolean): CursorPromise<T> {
     const makeRequest = async () => {
       if (!first && !this.meta.nextOffset) return;
@@ -22,13 +29,6 @@ export default class Cursor<T> {
     promise.next = this.next.bind(this);
     const cursorPromise = (promise: CursorPromise<T>);
     return cursorPromise;
-  }
-
-  constructor(
-    request: (meta?: CursorMeta) => Promise<CursorResponse<T>>
-  ): CursorPromise<T> {
-    this.request = request;
-    return ((this: any): CursorPromise<T>);
   }
 
   then(

--- a/src/AbstractAPI/Cursor.js
+++ b/src/AbstractAPI/Cursor.js
@@ -1,0 +1,47 @@
+/* @flow */
+import type { CursorMeta, CursorPromise, CursorResponse } from "../";
+
+export default class Cursor<T> {
+  lastResponse: ?Promise<CursorResponse<T> | void>;
+  meta: CursorMeta;
+  request: (meta?: CursorMeta) => Promise<CursorResponse<T>>;
+
+  get promise(): CursorPromise<T> {
+    return ((this: any): CursorPromise<T>);
+  }
+
+  _next(first?: boolean): CursorPromise<T> {
+    const makeRequest = async () => {
+      if (!first && !this.meta.nextOffset) return;
+      const response = await this.request(this.meta);
+      this.meta = response.meta;
+      return response;
+    };
+    this.lastResponse = this.lastResponse
+      ? this.lastResponse.then(makeRequest)
+      : makeRequest();
+    const promise = (this.lastResponse.then(
+      response => response && response.data
+    ): any);
+    promise.next = this.next.bind(this);
+    const cursorPromise = (promise: CursorPromise<T>);
+    return cursorPromise;
+  }
+
+  constructor(request: (meta?: CursorMeta) => Promise<CursorResponse<T>>) {
+    this.request = request;
+  }
+
+  then(
+    onFulfilled: (data: T) => *,
+    onRejected: (error: *) => *
+  ): CursorPromise<T> {
+    const cursorPromise = this._next(true);
+    cursorPromise.then(onFulfilled, onRejected);
+    return cursorPromise;
+  }
+
+  next(first?: boolean): CursorPromise<T> {
+    return this._next();
+  }
+}

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -198,7 +198,7 @@ export default class AbstractAPI implements AbstractInterface {
             meta: newMeta
           };
         }
-      ).promise;
+      );
     },
     info: async ({ activityId }: ActivityDescriptor) => {
       const response = await this.fetch(`activities/${activityId}`);
@@ -328,7 +328,7 @@ export default class AbstractAPI implements AbstractInterface {
           const response = await this.fetch(`comments?${query}`);
           return await response.json();
         }
-      ).promise;
+      );
     },
     info: async ({ commentId }: CommentDescriptor) => {
       const response = await this.fetch(`comments/${commentId}`);
@@ -578,7 +578,7 @@ export default class AbstractAPI implements AbstractInterface {
           const response = await this.fetch(`notifications?${query}`);
           return await response.json();
         }
-      ).promise;
+      );
     },
     info: async ({ notificationId }: NotificationDescriptor) => {
       const response = await this.fetch(`notifications/${notificationId}`);

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1247,6 +1247,23 @@ export type Notification =
   | NotificationReviewerRemoved
   | NotificationUpdateCommit;
 
+export interface CursorPromise<T> extends Promise<T> {
+  next(): CursorPromise<T>;
+}
+
+export type CursorMeta = {
+  limit: number,
+  maxCreatedAt: string,
+  nextOffset?: number,
+  offset: number,
+  total: number
+};
+
+export type CursorResponse<T> = {
+  data: T,
+  meta: CursorMeta
+};
+
 export interface AbstractInterface {
   accessToken: () => Promise<?string>;
 
@@ -1257,7 +1274,7 @@ export interface AbstractInterface {
         | OrganizationDescriptor
         | ProjectDescriptor,
       options?: ListOptions
-    ) => Promise<Activity[]>,
+    ) => CursorPromise<Activity[]>,
     info: (activityDescriptor: ActivityDescriptor) => Promise<Activity>
   };
 
@@ -1297,7 +1314,7 @@ export interface AbstractInterface {
         BranchDescriptor & CommitDescriptor & PageDescriptor & LayerDescriptor
       >,
       options?: ListOptions
-    ) => Promise<Comment[]>,
+    ) => CursorPromise<Comment[]>,
     info: (commentDescriptor: CommentDescriptor) => Promise<Comment>
   };
 
@@ -1351,10 +1368,8 @@ export interface AbstractInterface {
     list: (
       objectDescriptor?: OrganizationDescriptor,
       options?: ListOptions
-    ) => Promise<Notification[]>,
-    info: (
-      notificationDescriptor: NotificationDescriptor
-    ) => Promise<Notification>
+    ) => CursorPromise<Notification[]>,
+    info: (notificationDescriptor: NotificationDescriptor) => Promise<Notification>
   };
 }
 


### PR DESCRIPTION
This pull request adds support for cursor-based pagination.

From a high level, a paginated list method should return a special `Promise` that contains a `next` method. The most obvious way to satisfy this requirement is to extend the built-in `Promise` class. Unfortunately, Flow doesn't support class method overloads, but does support interface method overloads; this means it's seemingly impossible to subclass Flow's own `Promise` type interface since it includes [an overloaded `then` definition](https://github.com/facebook/flow/blob/master/lib/core.js#L618-L626) that can't actually be implemented with type safety.

To overcome this limitation, a combination of interface inheritance and indirect type casting was used. A `CursorPromise` interface was created that implements the `Promise` interface:

```js
interface CursorPromise<T> extends Promise<T> {
    next(): CursorPromise<T>;
}
```

An underlying `Cursor` class holds the actual implementation, and returned `Cursor` values are indirectly cast to `CursorPromise` objects (which is safe in this case since we know APIs are compatible):

```js
class Cursor<T> {
    next(): CursorPromise<T> {
       const response = /* ... */
       return ((response: any): CusorPromise<T>;
    }
}
```

Despite the type complexities, this implementation fully satisfies the API described in the [abstract-js doc](https://paper.dropbox.com/doc/abstract-js--ATFcyDMuLHE9NP36WHK7HhxIAg-sQIIqdls6ZRFpPsVABtK4#:uid=794781938248041307487637&h2=Pagination) in a type-safe manner for consumers:

```js
const firstPage = activities.list<Activity[]>();
const firstPageResults = await firstPage;
console.log(firstPageResults[0].foo); // Error: foo does not exist on Activity
console.log(firstPageResults[0].id); // 89f5e25b...
console.log(await firstPage); // [...]

const secondPage = firstPage.next();
console.log(await secondPage); // [...]

const thirdPage = secondPage.next();
console.log(await thirdPage) // undefined
```

Resolves #32