### PR TITLE
Allow accessToken option to be a function

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ const abstract = Abstract.Client({
 });
 ```
 
-You pass a function that returns a token.
+You can pass a function that returns a token.
 
 ```js
 import * as Abstract from "abstract-sdk";

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,28 @@ const abstract = Abstract.Client({
 });
 ```
 
+You pass a function that returns a token.
+
+```js
+import * as Abstract from "abstract-sdk";
+
+const abstract = Abstract.Client({
+  accessToken: () => Cookies.get("abstractToken")
+});
+```
+
+And you can pass a function that returns a promise to a token.
+
+```js
+import * as Abstract from "abstract-sdk";
+
+const abstract = Abstract.Client({
+  accessToken: () => {
+    return new Promise(resolve => resolve(Cookies.get("abstractToken")));
+  }
+});
+```
+
 ## Transports
 
 If you want to ensure that the SDK only ever loads data from the API or the CLI then you can achieve this by specifying a transport. This is useful when running in an environment without the Mac application installed or alternatively when you want to ensure you're only dealing with local data:

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -84,14 +84,19 @@ export default class AbstractAPI implements AbstractInterface {
       ? this._optionAccessToken
       : await this._optionAccessToken();
 
+  async tokenHeader() {
+    const accessToken = await this.accessToken();
+    return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
+  }
+
   async fetch(input: string | URL, init: Object = {}, hostname?: string) {
     init.headers = {
       Accept: "application/json",
       "Content-Type": "application/json",
       "User-Agent": `Abstract SDK ${minorVersion}`,
-      Authorization: `Bearer ${await this.accessToken()}`,
       "X-Amzn-Trace-Id": randomTraceId(),
       "Abstract-Api-Version": "8",
+      ...this.tokenHeader(),
       ...(init.headers || {})
     };
 

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -90,13 +90,15 @@ export default class AbstractAPI implements AbstractInterface {
   }
 
   async fetch(input: string | URL, init: Object = {}, hostname?: string) {
+    const tokenHeader = await this.tokenHeader();
+
     init.headers = {
       Accept: "application/json",
       "Content-Type": "application/json",
       "User-Agent": `Abstract SDK ${minorVersion}`,
       "X-Amzn-Trace-Id": randomTraceId(),
       "Abstract-Api-Version": "8",
-      ...this.tokenHeader(),
+      ...tokenHeader,
       ...(init.headers || {})
     };
 

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -22,7 +22,8 @@ import type {
   CommentDescriptor,
   Comment,
   Layer,
-  ListOptions
+  ListOptions,
+  AccessTokenOption
 } from "../";
 import parseShareURL from "./parseShareURL";
 import randomTraceId from "./randomTraceId";
@@ -33,7 +34,7 @@ const logStatusSuccess = log.extend("AbstractAPI:status:success");
 const logFetch = log.extend("AbstractAPI:fetch");
 
 export type Options = {
-  accessToken: string | (() => string | Promise<string>),
+  accessToken: AccessTokenOption,
   apiUrl?: string,
   previewsUrl?: string
 };
@@ -58,7 +59,7 @@ async function unwrapEnvelope<T>(
   return (await response).data;
 }
 export default class AbstractAPI implements AbstractInterface {
-  _optionAccessToken: string | (() => string | Promise<string>);
+  _optionAccessToken: AccessTokenOption;
   apiUrl: string;
   previewsUrl: string;
 

--- a/src/AbstractCLI/index.js
+++ b/src/AbstractCLI/index.js
@@ -15,7 +15,8 @@ import type {
   PageDescriptor,
   FileDescriptor,
   LayerDescriptor,
-  CollectionDescriptor
+  CollectionDescriptor,
+  AccessTokenOption
 } from "../";
 
 const logSpawn = log.extend("AbstractCLI:spawn");
@@ -31,14 +32,14 @@ function parsePath(input: ?string): ?Array<string> {
 }
 
 export type Options = {
-  accessToken: string | (() => string | Promise<string>),
+  accessToken: AccessTokenOption,
   cliPath?: string[],
   apiUrl?: string,
   cwd?: string
 };
 
 export default class AbstractCLI implements AbstractInterface {
-  _optionAccessToken: string | (() => string | Promise<string>);
+  _optionAccessToken: AccessTokenOption;
   cliPath: string;
   apiUrl: string;
   cwd: string;

--- a/src/Client/test.js
+++ b/src/Client/test.js
@@ -7,19 +7,19 @@ describe(Client, () => {
       jest.resetModules();
     });
 
-    test("configures options.accessToken from process.env.ABSTRACT_TOKEN", () => {
+    test("configures options.accessToken from process.env.ABSTRACT_TOKEN", async () => {
       process.env.ABSTRACT_TOKEN = "token-from-env";
       const { default: Client } = require("./");
-      expect(Client().accessToken).toBe("token-from-env");
+      expect(await Client().accessToken()).toBe("token-from-env");
     });
 
-    test("prefers options.accessToken over process.env.ABSTRACT_TOKEN", () => {
+    test("prefers options.accessToken over process.env.ABSTRACT_TOKEN", async () => {
       process.env.ABSTRACT_TOKEN = "token-from-env";
       const { default: Client } = require("./");
       expect(
-        Client({
+        await Client({
           accessToken: "token-from-options"
-        }).accessToken
+        }).accessToken()
       ).toBe("token-from-options");
     });
   });

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1357,3 +1357,8 @@ export interface AbstractInterface {
     ) => Promise<Notification>
   };
 }
+
+export type AccessTokenOption =
+  | string
+  | (() => string)
+  | (() => Promise<string>);

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1248,7 +1248,7 @@ export type Notification =
   | NotificationUpdateCommit;
 
 export interface AbstractInterface {
-  accessToken: () => Promise<string>;
+  accessToken: () => Promise<?string>;
 
   activities?: {
     list: (
@@ -1360,5 +1360,5 @@ export interface AbstractInterface {
 
 export type AccessTokenOption =
   | string
-  | (() => string)
-  | (() => Promise<string>);
+  | (() => ?string)
+  | (() => Promise<?string>);

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -24,7 +24,7 @@ export type ActivityDescriptor = {|
 
 export type NotificationDescriptor = {|
   notificationId: string
-|}
+|};
 
 type ObjectDescriptor = {|
   projectId: string,
@@ -1248,11 +1248,14 @@ export type Notification =
   | NotificationUpdateCommit;
 
 export interface AbstractInterface {
-  accessToken: string;
+  accessToken: () => Promise<string>;
 
   activities?: {
     list: (
-      objectDescriptor?: BranchDescriptor | OrganizationDescriptor | ProjectDescriptor,
+      objectDescriptor?:
+        | BranchDescriptor
+        | OrganizationDescriptor
+        | ProjectDescriptor,
       options?: ListOptions
     ) => Promise<Activity[]>,
     info: (activityDescriptor: ActivityDescriptor) => Promise<Activity>
@@ -1290,7 +1293,9 @@ export interface AbstractInterface {
     list: (
       {
         projectId: $PropertyType<ProjectDescriptor, "projectId">
-      } & $Shape<BranchDescriptor & CommitDescriptor & PageDescriptor & LayerDescriptor>,
+      } & $Shape<
+        BranchDescriptor & CommitDescriptor & PageDescriptor & LayerDescriptor
+      >,
       options?: ListOptions
     ) => Promise<Comment[]>,
     info: (commentDescriptor: CommentDescriptor) => Promise<Comment>
@@ -1347,6 +1352,8 @@ export interface AbstractInterface {
       objectDescriptor?: OrganizationDescriptor,
       options?: ListOptions
     ) => Promise<Notification[]>,
-    info: (notificationDescriptor: NotificationDescriptor) => Promise<Notification>
+    info: (
+      notificationDescriptor: NotificationDescriptor
+    ) => Promise<Notification>
   };
 }


### PR DESCRIPTION
Current implementation only accepts a string:

```js
import * as Abstract from "abstract-sdk";

const abstract = Abstract.Client({
  accessToken: process.env.ABSTRACT_API_TOKEN
});
```

New implementation accepts a function that returns a string:

```js
import * as Abstract from "abstract-sdk";

const abstract = Abstract.Client({
  accessToken: () => Cookies.get("authToken")
});
```

Or a function that returns a promise of a string:

```js
import * as Abstract from "abstract-sdk";

const abstract = Abstract.Client({
  accessToken: () => keytar.findPassword("abstract")
});
```

This is kind of a breaking change because the public-facing `Client` object has a public (but undocumented?) `accessToken` property that is currently a string but as of this PR is a function.

Should I add these use cases to the documentation?