### PR TITLE
Copy flow files so that the module returns typed values

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "prepublish": "yarn run build",
-    "build": "babel ./src -d ./lib && flow-copy-source src lib",
+    "build": "babel ./src --ignore **/*/__mocks__,**/test.js -d ./lib",
+    "prebuild": "flow-copy-source --ignore '**/*/__mocks__/*.js' --ignore '**/*test.js' ./src ./lib",
     "lint": "eslint .",
     "test": "jest",
     "test-inspect": "node --inspect-brk ./node_modules/.bin/jest --runInBand",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "lib/index.js",
   "scripts": {
     "prepublish": "yarn run build",
-    "build": "babel ./src -d ./lib",
+    "build": "babel ./src -d ./lib && flow-copy-source src lib",
     "lint": "eslint .",
     "test": "jest",
     "test-inspect": "node --inspect-brk ./node_modules/.bin/jest --runInBand",
@@ -46,6 +46,7 @@
     "eslint-plugin-prettier": "^2.6.2",
     "eslint-plugin-react": "^7.11.1",
     "flow-bin": "^0.80.0",
+    "flow-copy-source": "^2.0.2",
     "flow-typed": "^2.5.1",
     "jest": "^23.6.0",
     "jest-fetch-mock": "GrahamTheCoder/jest-fetch-mock#blob-fix",

--- a/src/AUTO/index.js
+++ b/src/AUTO/index.js
@@ -1,5 +1,5 @@
 // @flow
-import type { AbstractInterface } from "../";
+import type { AbstractInterface } from "../types";
 import AbstractCLI, { type Options as OptionsCLI } from "../AbstractCLI";
 import AbstractAPI, { type Options as OptionsAPI } from "../AbstractAPI";
 

--- a/src/AbstractAPI/Cursor.js
+++ b/src/AbstractAPI/Cursor.js
@@ -1,5 +1,5 @@
 /* @flow */
-import type { CursorMeta, CursorPromise, CursorResponse } from "../";
+import type { CursorMeta, CursorPromise, CursorResponse } from "../types";
 
 export default class Cursor<T> {
   lastResponse: ?Promise<CursorResponse<T> | void>;

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -23,7 +23,7 @@ import type {
   Comment,
   Layer,
   ListOptions
-} from "../";
+} from "../types";
 import parseShareURL from "./parseShareURL";
 import randomTraceId from "./randomTraceId";
 

--- a/src/AbstractCLI/index.js
+++ b/src/AbstractCLI/index.js
@@ -16,7 +16,7 @@ import type {
   FileDescriptor,
   LayerDescriptor,
   CollectionDescriptor
-} from "../";
+} from "../types";
 
 const logSpawn = log.extend("AbstractCLI:spawn");
 const logError = log.extend("AbstractCLI:error");

--- a/src/Client/index.js
+++ b/src/Client/index.js
@@ -1,5 +1,5 @@
 // @flow
-import type { AbstractInterface } from "../";
+import type { AbstractInterface } from "../types";
 import { AUTO } from "../transports";
 
 type Options = {

--- a/src/index.js
+++ b/src/index.js
@@ -5,3 +5,4 @@ import * as TRANSPORTS from "./transports";
 
 export { client, Sketch, TRANSPORTS };
 export { client as Client }; // Deprecated: prefer Abstract.client factory
+export type * from "./types";

--- a/src/sketch.js
+++ b/src/sketch.js
@@ -1,6 +1,10 @@
 // @flow
 /* global process NSString PROSketchBootstrap */
-import type { ProjectDescriptor, BranchDescriptor, FileDescriptor } from ".";
+import type {
+  ProjectDescriptor,
+  BranchDescriptor,
+  FileDescriptor
+} from "./types";
 
 export function isSketchPlugin() {
   // New versions of skpm set process type to "sketch". For older

--- a/src/support/factories.js
+++ b/src/support/factories.js
@@ -8,7 +8,7 @@ import type {
   LayerDescriptor,
   CollectionDescriptor,
   CommentDescriptor
-} from "../";
+} from "../types";
 
 export function buildOptions(options: *) {
   return {

--- a/src/types.js
+++ b/src/types.js
@@ -38,12 +38,12 @@ export type CommitDescriptor = {|
 
 export type BranchDescriptor = {|
   ...ObjectDescriptor,
-  sha: $PropertyType<ObjectDescriptor, "sha"> | "latest"
+  sha: $PropertyType<ObjectDescriptor, "sha">
 |};
 
 export type FileDescriptor = {|
   ...ObjectDescriptor,
-  sha: $PropertyType<ObjectDescriptor, "sha"> | "latest",
+  sha: $PropertyType<ObjectDescriptor, "sha">,
   fileId: string
 |};
 
@@ -55,7 +55,7 @@ export type PageDescriptor = {|
 
 export type LayerDescriptor = {|
   ...ObjectDescriptor,
-  sha: $PropertyType<ObjectDescriptor, "sha"> | "latest",
+  sha: $PropertyType<ObjectDescriptor, "sha">,
   fileId: string,
   pageId: string,
   layerId: string

--- a/src/types.js
+++ b/src/types.js
@@ -24,7 +24,7 @@ export type ActivityDescriptor = {|
 
 export type NotificationDescriptor = {|
   notificationId: string
-|}
+|};
 
 type ObjectDescriptor = {|
   projectId: string,
@@ -1252,7 +1252,10 @@ export interface AbstractInterface {
 
   activities?: {
     list: (
-      objectDescriptor?: BranchDescriptor | OrganizationDescriptor | ProjectDescriptor,
+      objectDescriptor?:
+        | BranchDescriptor
+        | OrganizationDescriptor
+        | ProjectDescriptor,
       options?: ListOptions
     ) => Promise<Activity[]>,
     info: (activityDescriptor: ActivityDescriptor) => Promise<Activity>
@@ -1290,7 +1293,9 @@ export interface AbstractInterface {
     list: (
       {
         projectId: $PropertyType<ProjectDescriptor, "projectId">
-      } & $Shape<BranchDescriptor & CommitDescriptor & PageDescriptor & LayerDescriptor>,
+      } & $Shape<
+        BranchDescriptor & CommitDescriptor & PageDescriptor & LayerDescriptor
+      >,
       options?: ListOptions
     ) => Promise<Comment[]>,
     info: (commentDescriptor: CommentDescriptor) => Promise<Comment>
@@ -1347,6 +1352,8 @@ export interface AbstractInterface {
       objectDescriptor?: OrganizationDescriptor,
       options?: ListOptions
     ) => Promise<Notification[]>,
-    info: (notificationDescriptor: NotificationDescriptor) => Promise<Notification>
+    info: (
+      notificationDescriptor: NotificationDescriptor
+    ) => Promise<Notification>
   };
 }

--- a/src/types.js
+++ b/src/types.js
@@ -1384,7 +1384,9 @@ export interface AbstractInterface {
       objectDescriptor?: OrganizationDescriptor,
       options?: ListOptions
     ) => CursorPromise<Notification[]>,
-    info: (notificationDescriptor: NotificationDescriptor) => Promise<Notification>
+    info: (
+      notificationDescriptor: NotificationDescriptor
+    ) => Promise<Notification>
   };
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,7 @@ import type {
   PageDescriptor,
   FileDescriptor,
   LayerDescriptor
-} from "./";
+} from "./types";
 
 export function objectBranchDescriptor(
   objectDescriptor:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2494,12 +2494,12 @@ fs.realpath@^1.0.0:
 fsevents@^1.2.2, fsevents@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
-  integrity sha1-LVUtnRG1UvS2nO/V6T2KZBR01yA=
+  integrity sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
   prebuiltVariants:
-    fsevents-v1.2.4-darwin-x64-57 "2d552d9d11b552f4b69cefd5e93d8a641474d720"
+    fsevents-v1.2.4-darwin-x64-57 "3f69dac5ce1ea824bccf6d0852713f570300fd4b"
 
 fstream@~1.0.10:
   version "1.0.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1391,6 +1391,11 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
+camelcase@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
+  integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
+
 caniuse-lite@^1.0.30000898:
   version "1.0.30000899"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000899.tgz#6febdbbc388a7982f620ee0e3d09aab0c061389e"
@@ -1445,7 +1450,7 @@ charenc@~0.0.1:
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
-chokidar@^2.0.3:
+chokidar@^2.0.0, chokidar@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
   integrity sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==
@@ -1641,6 +1646,17 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^6.0.0:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
@@ -1707,7 +1723,7 @@ debug@^4.0.1:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.1.1:
+decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -2127,6 +2143,19 @@ exec-sh@^0.2.0:
   dependencies:
     merge "^1.2.0"
 
+execa@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
+  integrity sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -2340,6 +2369,13 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
 flat-cache@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
@@ -2354,6 +2390,17 @@ flow-bin@^0.80.0:
   version "0.80.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.80.0.tgz#04cc1ee626a6f50786f78170c92ebe1745235403"
   integrity sha512-0wRnqvXErQRPrx6GBLB5swgndfWkotd9MgfePgT7Z+VsE046c8Apzl7KKTCypB/pzn0pZF2g5Jurxxb2umET8g==
+
+flow-copy-source@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/flow-copy-source/-/flow-copy-source-2.0.2.tgz#096e579a9bb63a38afc5d4dd68ac847a5be27594"
+  integrity sha512-IHKgy45Q+Xs7UanUZyFFJae/ubMKtzj0dU4vs1YoqlfKl2wzLTaqehyTpjqO4vLAnL48yGvLfnttncX5Utn/4g==
+  dependencies:
+    chokidar "^2.0.0"
+    fs-extra "^7.0.0"
+    glob "^7.0.0"
+    kefir "^3.7.3"
+    yargs "^12.0.1"
 
 flow-typed@^2.5.1:
   version "2.5.1"
@@ -2418,6 +2465,15 @@ fs-extra@^5.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -2438,12 +2494,12 @@ fs.realpath@^1.0.0:
 fsevents@^1.2.2, fsevents@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
-  integrity sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==
+  integrity sha1-LVUtnRG1UvS2nO/V6T2KZBR01yA=
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
   prebuiltVariants:
-    fsevents-v1.2.4-darwin-x64-57 "68372c379d6603f30c1591917ec8a75fb9cd2cd6"
+    fsevents-v1.2.4-darwin-x64-57 "2d552d9d11b552f4b69cefd5e93d8a641474d720"
 
 fstream@~1.0.10:
   version "1.0.11"
@@ -2815,6 +2871,11 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
+
+invert-kv@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
+  integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -3687,6 +3748,13 @@ jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
+kefir@^3.7.3:
+  version "3.8.5"
+  resolved "https://registry.yarnpkg.com/kefir/-/kefir-3.8.5.tgz#ce8d952707ea833d9d995a96b92daa744dea83ba"
+  integrity sha512-u4UxHyIvdOOM62Y/yAtYPeYEg/yUfwl5/QF3ksrTRxEdhpa7LAFChntZxVqbcf0gCGblZzL/JnV/gZYWOps3Qw==
+  dependencies:
+    symbol-observable "1.0.4"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -3722,6 +3790,13 @@ lcid@^1.0.0:
   integrity sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=
   dependencies:
     invert-kv "^1.0.0"
+
+lcid@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
+  integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
+  dependencies:
+    invert-kv "^2.0.0"
 
 left-pad@^1.3.0:
   version "1.3.0"
@@ -3845,6 +3920,13 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
+map-age-cleaner@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+  dependencies:
+    p-defer "^1.0.0"
+
 map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
@@ -3877,6 +3959,15 @@ mem@^1.1.0:
   integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
   dependencies:
     mimic-fn "^1.0.0"
+
+mem@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-4.0.0.tgz#6437690d9471678f6cc83659c00cbafcd6b0cdaf"
+  integrity sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==
+  dependencies:
+    map-age-cleaner "^0.1.1"
+    mimic-fn "^1.0.0"
+    p-is-promise "^1.1.0"
 
 merge-stream@^1.0.1:
   version "1.0.1"
@@ -4052,6 +4143,11 @@ needle@^2.2.1:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
     sax "^1.2.4"
+
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 node-fetch@2.1.2:
   version "2.1.2"
@@ -4283,6 +4379,15 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
+os-locale@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.0.1.tgz#3b014fbf01d87f60a1e5348d80fe870dc82c4620"
+  integrity sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==
+  dependencies:
+    execa "^0.10.0"
+    lcid "^2.0.0"
+    mem "^4.0.0"
+
 os-name@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/os-name/-/os-name-2.0.1.tgz#b9a386361c17ae3a21736ef0599405c9a8c5dc5e"
@@ -4318,10 +4423,20 @@ p-cancelable@^0.3.0:
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.3.0.tgz#b9e123800bcebb7ac13a479be195b507b98d30fa"
   integrity sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==
 
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-is-promise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
+  integrity sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -4422,7 +4537,7 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
@@ -5306,6 +5421,11 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
+symbol-observable@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+  integrity sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=
+
 symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
@@ -5784,6 +5904,11 @@ y18n@^3.2.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
   integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
 
+"y18n@^3.2.1 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -5793,6 +5918,14 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
   integrity sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=
+
+yargs-parser@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
+  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs-parser@^2.4.1:
   version "2.4.1"
@@ -5826,6 +5959,24 @@ yargs@^11.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
+
+yargs@^12.0.1:
+  version "12.0.5"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
+  integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^1.0.1"
+    os-locale "^3.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1 || ^4.0.0"
+    yargs-parser "^11.1.1"
 
 yargs@^4.2.0:
   version "4.8.1"


### PR DESCRIPTION
We've had a bit of conversation about how we should enable external flow type checking when using this module, and although we're not in agreement quite yet, I am opening this PR for discussion of its merits and because it unblocks me in trying to incorporate this module into our projects.

### The problem

By using `index.js.flow` as we would normally use a `types.js` file for all of our types, we end up _exporting_ our types, but they're not actually used when we import non-types. For instance, if you import

```js
import * as Abstract from "abstract-sdk";
```

`Abstract` is `any`.

### The possible solution in this PR

Move the current `index.js.flow` to `types.js` and use [`flow-copy-source`](https://www.npmjs.com/package/flow-copy-source) to copy uncompiled source code to `lib`, suffixed with `.flow`. This way, when you import from `abstract-sdk`, the actual code comes from `.js` files, but flow knows to look in their corresponding `.js.flow` files for typings. This is a really simple way to tell flow the types of the things that come from your module.

Now we have type checking and even completions working

<img width="518" alt="image" src="https://user-images.githubusercontent.com/216355/50165556-2d10fb80-02b3-11e9-8e7c-2f001fee5030.png">
<img width="516" alt="image" src="https://user-images.githubusercontent.com/216355/50165579-30a48280-02b3-11e9-918b-200f54e0e0e6.png">

### Tracking some issues using the module with flow enabled

- [ ] By returning `AbstractInterface` from `Abstract.Client`, you can't actually call something like `client.projects.list`, because `projects` is a maybe on `AbstractInterface`.