### PR TITLE
Fix issues with accessToken option function

### DIFF
--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -79,13 +79,10 @@ export default class AbstractAPI implements AbstractInterface {
     this.previewsUrl = previewsUrl;
   }
 
-  accessToken = async () => {
-    if (!this._optionAccessToken) return;
-    if (typeof this._optionAccessToken === "string") {
-      return this._optionAccessToken;
-    }
-    return this._optionAccessToken();
-  };
+  accessToken = async () =>
+    typeof this._optionAccessToken === "function"
+      ? this._optionAccessToken()
+      : this._optionAccessToken;
 
   async tokenHeader() {
     const accessToken = await this.accessToken();

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -79,10 +79,13 @@ export default class AbstractAPI implements AbstractInterface {
     this.previewsUrl = previewsUrl;
   }
 
-  accessToken = async () =>
-    typeof this._optionAccessToken === "string"
-      ? this._optionAccessToken
-      : await this._optionAccessToken();
+  accessToken = async () => {
+    if (!this._optionAccessToken) return;
+    if (typeof this._optionAccessToken === "string") {
+      return this._optionAccessToken;
+    }
+    return this._optionAccessToken();
+  };
 
   async tokenHeader() {
     const accessToken = await this.accessToken();

--- a/src/AbstractCLI/index.js
+++ b/src/AbstractCLI/index.js
@@ -71,13 +71,10 @@ export default class AbstractCLI implements AbstractInterface {
     }
   }
 
-  accessToken = async () => {
-    if (!this._optionAccessToken) return;
-    if (typeof this._optionAccessToken === "string") {
-      return this._optionAccessToken;
-    }
-    return this._optionAccessToken();
-  };
+  accessToken = async () =>
+    typeof this._optionAccessToken === "function"
+      ? this._optionAccessToken()
+      : this._optionAccessToken;
 
   async spawn(args: string[]) {
     const accessToken = await this.accessToken();

--- a/src/AbstractCLI/index.js
+++ b/src/AbstractCLI/index.js
@@ -71,10 +71,13 @@ export default class AbstractCLI implements AbstractInterface {
     }
   }
 
-  accessToken = async () =>
-    typeof this._optionAccessToken === "string"
-      ? this._optionAccessToken
-      : await this._optionAccessToken();
+  accessToken = async () => {
+    if (!this._optionAccessToken) return;
+    if (typeof this._optionAccessToken === "string") {
+      return this._optionAccessToken;
+    }
+    return this._optionAccessToken();
+  };
 
   async spawn(args: string[]) {
     const accessToken = await this.accessToken();

--- a/src/Client/index.js
+++ b/src/Client/index.js
@@ -13,11 +13,15 @@ type Options = {
 export default function Client(options: Options = {}): AbstractInterface {
   const Transport = options.transport || AUTO;
   const accessToken = options.accessToken || process.env.ABSTRACT_TOKEN;
-  const { apiUrl, cliPath, previewsUrl } = options;
 
   if (!Transport) {
     throw new Error("options.transport is required");
   }
 
-  return new Transport({ accessToken, cliPath, apiUrl, previewsUrl });
+  return new Transport({
+    accessToken,
+    cliPath: options.cliPath,
+    apiUrl: options.apiUrl,
+    previewsUrl: options.previewsUrl
+  });
 }

--- a/src/Client/index.js
+++ b/src/Client/index.js
@@ -1,22 +1,20 @@
 // @flow
-import type { AbstractInterface } from "../";
+import type { AbstractInterface, AccessTokenOption } from "../";
 import { AUTO } from "../transports";
 
 type Options = {
-  accessToken?: string,
+  accessToken?: AccessTokenOption,
   cliPath?: string[],
   apiUrl?: string,
   previewsUrl?: string,
   transport?: *
 };
 
-export default function Client({
-  accessToken = process.env.ABSTRACT_TOKEN || "",
-  cliPath,
-  apiUrl,
-  previewsUrl,
-  transport: Transport = AUTO
-}: Options = {}): AbstractInterface {
+export default function Client(options: Options = {}): AbstractInterface {
+  const Transport = options.transport || AUTO;
+  const accessToken = options.accessToken || process.env.ABSTRACT_TOKEN;
+  const { apiUrl, cliPath, previewsUrl } = options;
+
   if (!Transport) {
     throw new Error("options.transport is required");
   }

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1359,6 +1359,6 @@ export interface AbstractInterface {
 }
 
 export type AccessTokenOption =
-  | string
+  | ?string
   | (() => ?string)
   | (() => Promise<?string>);


### PR DESCRIPTION
- [x] `Abstract.Client` didn't accept the new `AccessTokenOption` type even though the underlying transports did.