### PR TITLE
feature: add organizations.info

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -635,18 +635,20 @@ Organizations contain users and projects.
 
 | Property                   | Type       | Description                                                                              |
 |----------------------------|------------|------------------------------------------------------------------------------------------|
-| `createdAt`                | `string`   | Timestamp that the organization was created                                              |
+| `billingEmail`             | `string`   | Billing email associated with this organization                                          |
+| `features`                 | `{[feature: string]: boolean}` | Map of feature flags enabled for this organization                   |
 | `hasBillingInfo`           | `boolean`  | Whether this organization has billing information on file                                |
 | `id`                       | `string`   | UUID                                                                                     |
 | `isUsernameOrganization`   | `boolean`  | A username organization is a free organization included with every user account          |
 | `isWithinSubscriptionTerm` | `boolean`  | Whether the organizations subscription is in good standing                               |
 | `logoUrl`                  | `string`   | A url for the organization logo                                                          |
 | `name`                     | `string`   | The name of the organization                                                             |
+| `privateProjectPublicSharingEnabled` | `boolean` | Flag indicating if this organization has sharing of private projects enabled    |
+| `publicSharingEnabled`     | `boolean`  | Flag indicating if this organization has sharing of public projects enabled              |
 | `restrictedToDomains`      | `string[]` | An optional list of domain names that invitations to this organization are restricted to |
 | `trialEndsAt`              | `string`   | Timestamp of when the trial ends, if within trial period                                 |
-| `updatedAt`                | `string`   | Timestamp that the organization was last updated                                         |
 | `userId`                   | `string`   | UUID of the user that created the organization                                           |
-
+| `userIds`                  | `string`   | Array of UUIDs of users that belong to this organization                                 |
 
 ### List all organizations
 
@@ -658,9 +660,16 @@ Load the organizations accessible by the current access token
 abstract.organizations.list();
 ```
 
-### Retrive an organization
+### Retrieve an organization
 
-  > Not yet implemented
+`organizations.info(OrganizationDescriptor): Promise<Organization>`
+
+Load the info for an organization
+
+```js
+abstract.organizations.info({
+  organizationId: "8a13eb62-a42f-435f-b3a3-39af939ad31b"
+});
 
 
 ## Pages

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -648,7 +648,6 @@ Organizations contain users and projects.
 | `restrictedToDomains`      | `string[]` | An optional list of domain names that invitations to this organization are restricted to |
 | `trialEndsAt`              | `string`   | Timestamp of when the trial ends, if within trial period                                 |
 | `userId`                   | `string`   | UUID of the user that created the organization                                           |
-| `userIds`                  | `string`   | Array of UUIDs of users that belong to this organization                                 |
 
 ### List all organizations
 

--- a/src/AbstractAPI/__snapshots__/test.js.snap
+++ b/src/AbstractAPI/__snapshots__/test.js.snap
@@ -844,6 +844,26 @@ Object {
 }
 `;
 
+exports[`AbstractAPI with mocked global.fetch organizations.info({"organizationId": "organization-id"}) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/organizations/organization-id",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": "8",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+  ],
+}
+`;
+
 exports[`AbstractAPI with mocked global.fetch organizations.list(undefined) 1`] = `
 Object {
   "fetch": Array [

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -194,6 +194,10 @@ export default class AbstractAPI implements AbstractInterface {
   };
 
   organizations = {
+    info: async ({ organizationId }: OrganizationDescriptor) => {
+      const response = await this.fetch(`organizations/${organizationId}`);
+      return unwrapEnvelope(response.json());
+    },
     list: async () => {
       const response = await this.fetch("organizations");
       return unwrapEnvelope(response.json());

--- a/src/AbstractAPI/test.js
+++ b/src/AbstractAPI/test.js
@@ -154,6 +154,7 @@ describe("AbstractAPI", () => {
         { responses: [responses.activities.info()] }
       ],
       // organizations
+      ["organizations.info", buildOrganizationDescriptor()],
       ["organizations.list", undefined],
       // shares
       ["shares.info", { url: "https://share.goabstract.com/share-id" }],

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -323,8 +323,20 @@ export type User = {
 };
 
 export type Organization = {
+  billingEmail?: string,
+  features: {[feature: string]: boolean},
+  hasBillingInfo?: boolean,
   id: string,
-  name: string
+  isUsernameOrganization?: boolean,
+  isWithinSubscriptionTerm?: boolean,
+  logoUrl?: string,
+  name: string,
+  privateProjectPublicSharingEnabled?: boolean,
+  publicSharingEnabled?: boolean,
+  restrictedToDomains: string[],
+  trialEndsAt?: string,
+  userId: string,
+  userIds: string[]
 };
 
 export type Project = {
@@ -1262,7 +1274,8 @@ export interface AbstractInterface {
   };
 
   organizations?: {
-    list: () => Promise<Branch[]>
+    info: (organizationDescriptor: OrganizationDescriptor) => Promise<Organization>,
+    list: () => Promise<Organization[]>
   };
 
   shares?: {


### PR DESCRIPTION
This pull request adds `organizations.info` support to the API transport.

Resolves #53 