### PR TITLE
feature: add users.list and users.info

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -868,7 +868,7 @@ const branchFiles = await abstract.files.list(branchShare.descriptor);
 
 ## Users
 
-A user contains information specific to an individual account. Users are created by creating a new account.
+A user contains information specific to an individual account. Users are global to Abstract and are not specific to organizations. A user is created in the application by creating a new account.
 
 ![API][api-icon]
 
@@ -883,7 +883,6 @@ A user contains information specific to an individual account. Users are created
 | `id`              | `string` | UUID identifier for the user                                 |
 | `name`            | `string` | The name of the page                                         |
 | `primaryEmailId`  | `string` | ID of the primary email for this user                        |
-| `releaseChannel`  | `string` | Release channel this user belongs to                         |
 | `updatedAt`       | `string` | Timestamp indicating when this account was updated           |
 | `username`        | `string` | Username associated with this user                           |
 
@@ -1021,7 +1020,5 @@ Reference for the parameters required to load resources with Abstract SDK.
 ### UserDescriptor
 
  ```js
-{
-  userId: string
-}
+{ userId: string }
 ```

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -866,6 +866,52 @@ const branchFiles = await abstract.files.list(branchShare.descriptor);
 ```
 
 
+## Users
+
+A user contains information specific to an individual account. Users are created by creating a new account.
+
+![API][api-icon]
+
+### The user object
+
+| Property          | Type     | Description                                                  |
+|-------------------|----------|--------------------------------------------------------------|
+| `avatarUrl`       | `string` | URL of the avatar for this user                              |
+| `createdAt`       |  `string`| Timestamp indicating when this account was created           |
+| `deletedAt`       | `string` | Timestamp indicating when this account was deleted           |
+| `email`           | `string` | Email associated with this user account                      |
+| `id`              | `string` | UUID identifier for the user                                 |
+| `name`            | `string` | The name of the page                                         |
+| `primaryEmailId`  | `string` | ID of the primary email for this user                        |
+| `releaseChannel`  | `string` | Release channel this user belongs to                         |
+| `updatedAt`       | `string` | Timestamp indicating when this account was updated           |
+| `username`        | `string` | Username associated with this user                           |
+
+### List all users
+
+`users.list(OrganizationDescriptor | ProjectDescriptor): Promise<User[]>`
+
+List the users in an organization
+
+```js
+abstract.users.list({
+  organizationId: "d147fba5-c713-4fb9-ab16-e7e82ed9cbc9"
+});
+```
+
+### Retrieve a user
+
+`users.info(UserDescriptor): Promise<User>`
+
+Load the info for a specific user
+
+```js
+abstract.users.info({
+  userId: "48b5d670-2002-45ea-929d-4b00863778e4"
+});
+```
+
+
 ## Descriptors
 
 Reference for the parameters required to load resources with Abstract SDK.
@@ -969,5 +1015,13 @@ Reference for the parameters required to load resources with Abstract SDK.
  ```js
 {
   commentId: string
+}
+```
+
+### UserDescriptor
+
+ ```js
+{
+  userId: string
 }
 ```

--- a/src/AbstractAPI/__snapshots__/test.js.snap
+++ b/src/AbstractAPI/__snapshots__/test.js.snap
@@ -432,6 +432,26 @@ Object {
 }
 `;
 
+exports[`AbstractAPI with mocked global.fetch comments.info({"userId": "user-id"}) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/comments/undefined",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": "8",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+  ],
+}
+`;
+
 exports[`AbstractAPI with mocked global.fetch comments.list({"projectId": "project-id"}) 1`] = `
 Object {
   "fetch": Array [
@@ -1035,6 +1055,46 @@ Object {
   "fetch": Array [
     Array [
       "https://api.goabstract.com/share_links/share-id",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": "8",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+  ],
+}
+`;
+
+exports[`AbstractAPI with mocked global.fetch users.list({"organizationId": "organization-id"}) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/organizations/organization-id/memberships",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": "8",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+  ],
+}
+`;
+
+exports[`AbstractAPI with mocked global.fetch users.list({"projectId": "project-id"}) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/projects/project-id/memberships",
       Object {
         "headers": Object {
           "Abstract-Api-Version": "8",

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -20,6 +20,7 @@ import type {
   ActivityDescriptor,
   NotificationDescriptor,
   CommentDescriptor,
+  UserDescriptor,
   Comment,
   Layer,
   ListOptions,
@@ -563,6 +564,26 @@ export default class AbstractAPI implements AbstractInterface {
     },
     info: async ({ notificationId }: NotificationDescriptor) => {
       const response = await this.fetch(`notifications/${notificationId}`);
+      return response.json();
+    }
+  };
+
+  users = {
+    list: async (
+      objectDescriptor: OrganizationDescriptor | ProjectDescriptor
+    ) => {
+      let url = "";
+      if (objectDescriptor.organizationId) {
+        url = `organizations/${objectDescriptor.organizationId}/memberships`;
+      } else if (objectDescriptor.projectId) {
+        url = `projects/${objectDescriptor.projectId}/memberships`;
+      }
+      const response = await this.fetch(url);
+      const memberships = await unwrapEnvelope(response.json());
+      return memberships.map(membership => membership.user);
+    },
+    info: async ({ userId }: UserDescriptor) => {
+      const response = await this.fetch(`users/${userId}`);
       return response.json();
     }
   };

--- a/src/AbstractAPI/test.js
+++ b/src/AbstractAPI/test.js
@@ -15,7 +15,8 @@ import {
   buildCollectionDescriptor,
   buildActivityDescriptor,
   buildNotificationDescriptor,
-  buildCommentDescriptor
+  buildCommentDescriptor,
+  buildUserDescriptor
 } from "../support/factories";
 import { log } from "../debug";
 import AbstractAPI from "./";
@@ -115,6 +116,15 @@ const responses = {
     info: () => [JSON.stringify({ id: "foo" }), { status: 200 }]
   },
   comments: {
+    list: () => [
+      JSON.stringify({
+        data: [{ id: "foo" }, { id: "bar" }]
+      }),
+      { status: 200 }
+    ],
+    info: () => [JSON.stringify({ id: "foo" }), { status: 200 }]
+  },
+  users: {
     list: () => [
       JSON.stringify({
         data: [{ id: "foo" }, { id: "bar" }]
@@ -346,6 +356,22 @@ describe("AbstractAPI", () => {
         "notifications.info",
         buildNotificationDescriptor(),
         { responses: [responses.notifications.info()] }
+      ],
+      // users
+      [
+        "users.list",
+        buildProjectDescriptor(),
+        { responses: [responses.users.list()] }
+      ],
+      [
+        "users.list",
+        buildOrganizationDescriptor(),
+        { responses: [responses.users.list()] }
+      ],
+      [
+        "comments.info",
+        buildUserDescriptor(),
+        { responses: [responses.users.info()] }
       ]
     ])("%s(%p)", async (property, args, options = {}) => {
       args = Array.isArray(args) ? args : [args];

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -63,6 +63,10 @@ export type LayerDescriptor = {|
 
 export type ShareDescriptor = {| url: string |} | {| shareId: string |};
 
+export type UserDescriptor = {|
+  userId: string
+|};
+
 export type ListOptions = {
   limit?: number,
   offset?: number
@@ -1355,6 +1359,15 @@ export interface AbstractInterface {
     info: (
       notificationDescriptor: NotificationDescriptor
     ) => Promise<Notification>
+  };
+
+  users?: {
+    list: (
+      objectDescriptor: OrganizationDescriptor | ProjectDescriptor
+    ) => Promise<User[]>,
+    info: (
+      userDescriptor: UserDescriptor
+    ) => Promise<User>
   };
 }
 

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -322,7 +322,6 @@ export type User = {
   deletedAt: string,
   username: string,
   name: ?string,
-  releaseChannel: ?string,
   avatarUrl: ?string
 };
 

--- a/src/support/factories.js
+++ b/src/support/factories.js
@@ -7,7 +7,8 @@ import type {
   PageDescriptor,
   LayerDescriptor,
   CollectionDescriptor,
-  CommentDescriptor
+  CommentDescriptor,
+  UserDescriptor
 } from "../";
 
 export function buildOptions(options: *) {
@@ -115,5 +116,12 @@ export function buildCommentDescriptor(
   return {
     commentId: "comment-id",
     ...commentDescriptor
+  };
+}
+
+export function buildUserDescriptor(userDescriptor: *): UserDescriptor {
+  return {
+    userId: "user-id",
+    ...userDescriptor
   };
 }


### PR DESCRIPTION
This pull request adds support for `users.list` and `users.info` to the API transport.

Requires https://github.com/goabstract/projects/pull/1133
Resolves https://github.com/goabstract/abstract-sdk/issues/55