### PR TITLE
feature: add branches.info and branches.list to CLI

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -50,13 +50,10 @@ abstract.activities.info({
 
 ## Branches
 
-![API][api-icon]
+![CLI][cli-icon] ![API][api-icon]
 
 A branch is where design work and commits happen. A branch acts as a personal workspace for contributors, we encourage branches
 to be created for logical chunks of work – for example designing a new feature.
-
-  > Note: Branches will be available through the CLI transport in the near future
-
 
 ### The branch object
 

--- a/src/AbstractCLI/__snapshots__/test.js.snap
+++ b/src/AbstractCLI/__snapshots__/test.js.snap
@@ -1,5 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AbstractCLI with mocked child_process.spawn branches.info({"branchId": "branch-id", "projectId": "project-id", "sha": "branch-sha"}) 1`] = `
+Object {
+  "spawn": Array [
+    Array [
+      "<PROJECT_ROOT>/fixtures/abstract-cli",
+      Array [
+        "--user-token",
+        "abstract-token",
+        "--api-url",
+        "https://api.goabstract.com",
+        "branch",
+        "load",
+        "branch-id",
+        "project-id",
+      ],
+      Object {
+        "cwd": "<PROJECT_ROOT>",
+      },
+    ],
+  ],
+}
+`;
+
+exports[`AbstractCLI with mocked child_process.spawn branches.list({"projectId": "project-id"}) 1`] = `
+Object {
+  "spawn": Array [
+    Array [
+      "<PROJECT_ROOT>/fixtures/abstract-cli",
+      Array [
+        "--user-token",
+        "abstract-token",
+        "--api-url",
+        "https://api.goabstract.com",
+        "branches",
+        "project-id",
+      ],
+      Object {
+        "cwd": "<PROJECT_ROOT>",
+      },
+    ],
+  ],
+}
+`;
+
 exports[`AbstractCLI with mocked child_process.spawn changesets.info({"branchId": "branch-id", "projectId": "project-id", "sha": "commit-sha"}) 1`] = `
 Object {
   "spawn": Array [

--- a/src/AbstractCLI/index.js
+++ b/src/AbstractCLI/index.js
@@ -317,4 +317,21 @@ export default class AbstractCLI implements AbstractInterface {
       ]);
     }
   };
+
+  branches = {
+    list: async (projectDescriptor: ProjectDescriptor) => {
+      const data = await this.spawn(["branches", projectDescriptor.projectId]);
+      return data.branches;
+    },
+    info: async (branchDescriptor: BranchDescriptor) => {
+      const data = await this.spawn([
+        "branch",
+        "load",
+        branchDescriptor.branchId,
+        branchDescriptor.projectId
+      ]);
+
+      return data;
+    }
+  };
 }

--- a/src/AbstractCLI/test.js
+++ b/src/AbstractCLI/test.js
@@ -62,6 +62,16 @@ const responses = {
     info: () => ({
       stdout: JSON.stringify({ layer: { id: "layer-id" } })
     })
+  },
+  branches: {
+    list: () => ({
+      stdout: JSON.stringify({
+        branches: [{ id: "foo" }, { id: "bar" }]
+      })
+    }),
+    info: () => ({
+      stdout: JSON.stringify({ id: "baz" })
+    })
   }
 };
 
@@ -213,6 +223,17 @@ describe(AbstractCLI, () => {
         "data.info",
         buildLayerDescriptor({ sha: "latest" }),
         { responses: [responses.commits.list()] }
+      ],
+      // branches
+      [
+        "branches.list",
+        buildProjectDescriptor(),
+        { responses: [responses.branches.list()] }
+      ],
+      [
+        "branches.info",
+        buildBranchDescriptor(),
+        { responses: [responses.branches.info()] }
       ]
     ])("%s(%p)", async (property, args, options = {}) => {
       args = Array.isArray(args) ? args : [args];

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1347,7 +1347,7 @@ export interface AbstractInterface {
   branches?: {
     list: (
       ProjectDescriptor,
-      options: { filter?: "active" | "archived" | "mine" }
+      options?: { filter?: "active" | "archived" | "mine" }
     ) => Promise<Branch[]>,
     info: BranchDescriptor => Promise<Branch>
   };


### PR DESCRIPTION
This pull request adds `branches.info` and `branches.list` support to the CLI transport.

Requires https://github.com/goabstract/projects/pull/1199
Resolves https://github.com/goabstract/abstract-sdk/issues/54