### PR TITLE
feature: add assets endpoints to the API transport

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -6,6 +6,7 @@ title: Client
 [cli-icon]: https://img.shields.io/badge/CLI-lightgrey.svg
 [api-icon]: https://img.shields.io/badge/API-blue.svg
 
+
 ## Activities
 
 ![API][api-icon]
@@ -47,6 +48,82 @@ abstract.activities.info({
   activityId: "616daa90-1736-11e8-b8b0-8d1fec7aef78"
 });
 ```
+
+
+[cli-icon]: https://img.shields.io/badge/CLI-lightgrey.svg
+[api-icon]: https://img.shields.io/badge/API-blue.svg
+
+
+## Assets
+
+![API][api-icon]
+
+An asset represents an exportable resource from a Sketch file. Files are automatically scanned for new assets as new commits are pushed to a project.
+
+### The asset object
+
+| Property      | Type                | Description                                                                             |
+|---------------|---------------------|-----------------------------------------------------------------------------------------|
+| `createdAt`   | `string`            | Timestamp at which the asset was created                                                |
+| `defaultAbstractFormat` | `boolean` | Indicates if this asset is the default asset for a layer                                |
+| `fileFormat`  | `string`            | File type of this asset                                                                 |
+| `fileId`      | `string`            | File ID of this asset                                                                   |
+| `formatName`  | `string`            | Format of this file, e.g. "2x"                                                          |
+| `id`          | `string`            | UUID identifier of the asset                                                            |
+| `layerId`     | `string`            | UUID of the layer this asset belongs to                                                 |
+| `layerName`   | `string`            | Name of the layer this asset belongs to                                                 |
+| `namingScheme`| `string`            | Indicates the naming convention used for this asset                                     |
+| `nestedLayerId` | `string`          | ID of the nested layer this asset belongs to                                            |
+| `projectId`   | `string`            | ID of the project this layer belongs to                                                 |
+| `scale`       | `string`            | Scale of this asset in pixels                                                           |
+| `sha`         | `string`            | SHA of the commit containing the version of the file this asset belongs to              |
+| `url`         | `string`            | Direct URL to the asset file                                                            |
+
+### List all assets
+
+`assets.list(BranchDescriptor): Promise<Asset[]>`
+
+List all assets for a commit on a given branch of a project
+
+```js
+abstract.assets.list({
+  branchId: "8a13eb62-a42f-435f-b3a3-39af939ad31b",
+  projectId: "b8bf5540-6e1e-11e6-8526-2d315b6ef48f",
+  sha: "c4e5578c590f5334349b6d7f0dfd4d3882361f1a", // or sha: "latest"
+});
+```
+
+### Retrieve an asset
+
+`asset.info(AssetDescriptor): Promise<Asset>`
+
+Load the info for an asset
+
+```js
+abstract.assets.info({
+  assetId: "fcd67bab-e5c3-4679-b879-daa5d5746cc2",
+  projectId: "b8bf5540-6e1e-11e6-8526-2d315b6ef48f"
+});
+```
+
+### Retrieve an asset file
+
+`asset.raw(AssetDescriptor): Promise<ArrayBuffer>`
+
+Load given asset file based on its ID. The resulting `ArrayBuffer` can be used with node `fs` APIs. For example, it's possible to write the image to disk:
+
+```js
+const arrayBuffer = abstract.assets.raw({
+  assetId: "fcd67bab-e5c3-4679-b879-daa5d5746cc2",
+  projectId: "b8bf5540-6e1e-11e6-8526-2d315b6ef48f"
+});
+
+fs.writeFile("asset.png", Buffer.from(arrayBuffer), (err) => {
+  if (err) throw err;
+  console.log("Asset image written!");
+});
+```
+
 
 ## Branches
 
@@ -738,10 +815,10 @@ only available in PNG format.
 
 `previews.raw(LayerDescriptor): Promise<ArrayBuffer>`
 
-Load the preview image for a layer at a commit. The resulting `Buffer` can be used with node `fs` API's – for example you can write the image to disk:
+Load the preview image for a layer at a commit. The resulting `ArrayBuffer` can be used with node `fs` API's – for example you can write the image to disk:
 
 ```js
-const buffer = await abstract.previews.raw({
+const arrayBuffer = await abstract.previews.raw({
   projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78",
   branchId: "master",
   fileId: "51DE7CD1-ECDC-473C-B30E-62AE913743B7",
@@ -750,7 +827,7 @@ const buffer = await abstract.previews.raw({
   sha: "c4e5578c590f5334349b6d7f0dfd4d3882361f1a" // or sha: "latest"
 });
 
-fs.writeFile(`preview.png`, buffer, (err) => {
+fs.writeFile(`preview.png`, Buffer.from(arrayBuffer), (err) => {
   if (err) throw err;
   console.log("Preview image written!");
 });
@@ -1030,4 +1107,13 @@ Reference for the parameters required to load resources with Abstract SDK.
 
  ```js
 { userId: string }
+```
+
+### AssetDescriptor
+
+ ```js
+{
+  assetId: string,
+  projectId: string
+}
 ```

--- a/src/AbstractAPI/__snapshots__/test.js.snap
+++ b/src/AbstractAPI/__snapshots__/test.js.snap
@@ -80,6 +80,79 @@ Object {
 }
 `;
 
+exports[`AbstractAPI with mocked global.fetch assets.info({"assetId": "asset-id", "projectId": "project-id"}) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/projects/project-id/assets/asset-id",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": "8",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+  ],
+}
+`;
+
+exports[`AbstractAPI with mocked global.fetch assets.list({"branchId": "branch-id", "projectId": "project-id", "sha": "branch-sha"}) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/projects/project-id/assets?sha=branch-sha",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": "8",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+  ],
+}
+`;
+
+exports[`AbstractAPI with mocked global.fetch assets.raw({"assetId": "asset-id", "projectId": "project-id"}) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/projects/project-id/assets/asset-id",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": "8",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+    Array [
+      "assets",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": undefined,
+          "Accept": undefined,
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": undefined,
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+  ],
+}
+`;
+
 exports[`AbstractAPI with mocked global.fetch branches.info({"branchId": "branch-id", "projectId": "project-id", "sha": "branch-sha"}) 1`] = `
 Object {
   "fetch": Array [

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -21,6 +21,7 @@ import type {
   NotificationDescriptor,
   CommentDescriptor,
   UserDescriptor,
+  AssetDescriptor,
   Comment,
   Layer,
   ListOptions,
@@ -110,8 +111,9 @@ export default class AbstractAPI implements AbstractInterface {
       init.body = JSON.stringify(init.body);
     }
 
-    hostname = hostname || this.apiUrl;
-    const fetchArgs = [`${hostname}/${input.toString()}`, init];
+    hostname = typeof hostname === "string" ? hostname : this.apiUrl;
+    const hostnameRoot = hostname.length > 0 ? `${hostname}/` : "";
+    const fetchArgs = [`${hostnameRoot}${input.toString()}`, init];
 
     logFetch(fetchArgs);
     const request = fetch(...fetchArgs);
@@ -608,6 +610,41 @@ export default class AbstractAPI implements AbstractInterface {
     info: async ({ userId }: UserDescriptor) => {
       const response = await this.fetch(`users/${userId}`);
       return response.json();
+    }
+  };
+
+  assets = {
+    info: async ({ assetId, projectId }: AssetDescriptor) => {
+      const response = await this.fetch(
+        `projects/${projectId}/assets/${assetId}`
+      );
+      return response.json();
+    },
+    list: async (objectDescriptor: BranchDescriptor) => {
+      objectDescriptor = await this.resolveDescriptor(objectDescriptor);
+      const query = queryString.stringify({
+        sha: objectDescriptor && objectDescriptor.sha
+      });
+      const response = await this.fetch(
+        `projects/${objectDescriptor.projectId}/assets?${query}`
+      );
+      const { assets } = await unwrapEnvelope(response.json());
+      return assets;
+    },
+    raw: async (assetDescriptor: AssetDescriptor) => {
+      const asset = await this.assets.info(assetDescriptor);
+      const response = await this.fetch(
+        asset.url,
+        {
+          headers: {
+            Accept: undefined,
+            "Content-Type": undefined,
+            "Abstract-Api-Version": undefined
+          }
+        },
+        ""
+      );
+      return response.arrayBuffer();
     }
   };
 

--- a/src/AbstractAPI/test.js
+++ b/src/AbstractAPI/test.js
@@ -16,7 +16,8 @@ import {
   buildActivityDescriptor,
   buildNotificationDescriptor,
   buildCommentDescriptor,
-  buildUserDescriptor
+  buildUserDescriptor,
+  buildAssetDescriptor
 } from "../support/factories";
 import { log } from "../debug";
 import AbstractAPI from "./";
@@ -30,6 +31,9 @@ jest.mock("../../package.json", () => ({
 global.fetch = fetch;
 
 const logTest = log.extend("AbstractAPI:test");
+const buffer = fs.readFileSync(
+  path.resolve(__dirname, "../../fixtures/preview.png")
+);
 
 const responses = {
   activities: {
@@ -99,12 +103,7 @@ const responses = {
     ]
   },
   previews: {
-    arrayBuffer: (
-      // inlined to avoid multiple reads
-      data = fs.readFileSync(
-        path.resolve(__dirname, "../../fixtures/preview.png")
-      )
-    ) => [data, { status: 200 }]
+    arrayBuffer: () => [buffer, { status: 200 }]
   },
   notifications: {
     list: () => [
@@ -114,6 +113,16 @@ const responses = {
       { status: 200 }
     ],
     info: () => [JSON.stringify({ id: "foo" }), { status: 200 }]
+  },
+  assets: {
+    list: () => [
+      JSON.stringify({
+        data: [{ id: "foo" }, { id: "bar" }]
+      }),
+      { status: 200 }
+    ],
+    info: () => [JSON.stringify({ id: "foo", url: "assets" }), { status: 200 }],
+    arrayBuffer: () => [buffer, { status: 200 }]
   },
   comments: {
     list: () => [
@@ -357,6 +366,33 @@ describe("AbstractAPI", () => {
         "notifications.info",
         buildNotificationDescriptor(),
         { responses: [responses.notifications.info()] }
+      ],
+      // assets
+      [
+        "assets.list",
+        buildBranchDescriptor(),
+        { responses: [responses.assets.list()] }
+      ],
+      [
+        "assets.info",
+        buildAssetDescriptor(),
+        { responses: [responses.assets.info()] }
+      ],
+      [
+        "assets.raw",
+        buildAssetDescriptor(),
+        {
+          responses: [responses.assets.info(), responses.previews.arrayBuffer()]
+        },
+        "assets.raw",
+        buildAssetDescriptor({ sha: "latest" }),
+        {
+          responses: [
+            responses.commits.list(),
+            responses.assets.info(),
+            responses.assets.arrayBuffer()
+          ]
+        }
       ],
       // users
       [

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -67,6 +67,11 @@ export type UserDescriptor = {|
   userId: string
 |};
 
+export type AssetDescriptor ={|
+  assetId: string,
+  projectId: string
+|};
+
 export type ListOptions = {
   limit?: number,
   offset?: number
@@ -1262,6 +1267,23 @@ export type Notification =
   | NotificationReviewerRemoved
   | NotificationUpdateCommit;
 
+export type Asset = {
+  createdAt: string,
+  defaultAbstractFormat: boolean,
+  fileFormat: string,
+  fileId: string,
+  formatName: string,
+  id: string,
+  layerId: string,
+  layerName: string,
+  namingScheme: string,
+  nestedLayerId: string,
+  projectId: string,
+  scale: string,
+  sha: string,
+  url: string,
+};
+
 export interface CursorPromise<T> extends Promise<T> {
   next(): CursorPromise<T>;
 }
@@ -1396,6 +1418,18 @@ export interface AbstractInterface {
       userDescriptor: UserDescriptor
     ) => Promise<User>
   };
+
+  assets?: {
+    list: (
+      objectDescriptor: BranchDescriptor
+    ) => Promise<Asset[]>,
+    info: (
+      assetDescriptor: AssetDescriptor
+    ) => Promise<Asset>,
+    raw: (
+      assetDescriptor: AssetDescriptor
+    ) => Promise<ArrayBuffer>
+  }
 }
 
 export type AccessTokenOption =

--- a/src/support/factories.js
+++ b/src/support/factories.js
@@ -8,7 +8,8 @@ import type {
   LayerDescriptor,
   CollectionDescriptor,
   CommentDescriptor,
-  UserDescriptor
+  UserDescriptor,
+  AssetDescriptor
 } from "../";
 
 export function buildOptions(options: *) {
@@ -123,5 +124,13 @@ export function buildUserDescriptor(userDescriptor: *): UserDescriptor {
   return {
     userId: "user-id",
     ...userDescriptor
+  };
+}
+
+export function buildAssetDescriptor(assetDescriptor: *): AssetDescriptor {
+  return {
+    assetId: "asset-id",
+    projectId: "project-id",
+    ...assetDescriptor
   };
 }


### PR DESCRIPTION
This pull request updates the API transport by adding `assets`-related endpoints.

Requires https://github.com/goabstract/projects/pull/1200
Resolves #52 