### PR TITLE
Fix for commits.info(layer|file) at latest

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -1021,9 +1021,7 @@ Reference for the parameters required to load resources with Abstract SDK.
 
 ### CommentDescriptor
  ```js
-{
-  commentId: string
-}
+{ commentId: string }
 ```
 
 ### UserDescriptor

--- a/src/AbstractAPI/__snapshots__/test.js.snap
+++ b/src/AbstractAPI/__snapshots__/test.js.snap
@@ -492,11 +492,51 @@ Object {
 }
 `;
 
+exports[`AbstractAPI with mocked global.fetch commits.info({"branchId": "branch-id", "fileId": "file-id", "layerId": "layer-id", "pageId": "page-id", "projectId": "project-id", "sha": "latest"}) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?fileId=file-id&layerId=layer-id",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": "8",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+  ],
+}
+`;
+
 exports[`AbstractAPI with mocked global.fetch commits.info({"branchId": "branch-id", "fileId": "file-id", "projectId": "project-id", "sha": "commit-sha"}) 1`] = `
 Object {
   "fetch": Array [
     Array [
       "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": "8",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+  ],
+}
+`;
+
+exports[`AbstractAPI with mocked global.fetch commits.info({"branchId": "branch-id", "fileId": "file-id", "projectId": "project-id", "sha": "latest"}) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?fileId=file-id",
       Object {
         "headers": Object {
           "Abstract-Api-Version": "8",

--- a/src/AbstractAPI/__snapshots__/test.js.snap
+++ b/src/AbstractAPI/__snapshots__/test.js.snap
@@ -572,6 +572,26 @@ Object {
 }
 `;
 
+exports[`AbstractAPI with mocked global.fetch commits.info({"branchId": "branch-id", "projectId": "project-id", "sha": "commit-sha"}) 2`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?",
+      Object {
+        "headers": Object {
+          "Abstract-Api-Version": "8",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+      },
+    ],
+  ],
+}
+`;
+
 exports[`AbstractAPI with mocked global.fetch commits.list({"branchId": "branch-id", "fileId": "file-id", "layerId": "layer-id", "pageId": "page-id", "projectId": "project-id", "sha": "layer-sha"}) 1`] = `
 Object {
   "fetch": Array [

--- a/src/AbstractAPI/__snapshots__/test.js.snap
+++ b/src/AbstractAPI/__snapshots__/test.js.snap
@@ -476,7 +476,7 @@ exports[`AbstractAPI with mocked global.fetch commits.info({"branchId": "branch-
 Object {
   "fetch": Array [
     Array [
-      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?",
+      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?limit=1",
       Object {
         "headers": Object {
           "Abstract-Api-Version": "8",
@@ -496,7 +496,7 @@ exports[`AbstractAPI with mocked global.fetch commits.info({"branchId": "branch-
 Object {
   "fetch": Array [
     Array [
-      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?fileId=file-id&layerId=layer-id",
+      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?fileId=file-id&layerId=layer-id&limit=1",
       Object {
         "headers": Object {
           "Abstract-Api-Version": "8",
@@ -516,7 +516,7 @@ exports[`AbstractAPI with mocked global.fetch commits.info({"branchId": "branch-
 Object {
   "fetch": Array [
     Array [
-      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?",
+      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?limit=1",
       Object {
         "headers": Object {
           "Abstract-Api-Version": "8",
@@ -536,7 +536,7 @@ exports[`AbstractAPI with mocked global.fetch commits.info({"branchId": "branch-
 Object {
   "fetch": Array [
     Array [
-      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?fileId=file-id",
+      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?fileId=file-id&limit=1",
       Object {
         "headers": Object {
           "Abstract-Api-Version": "8",
@@ -556,7 +556,7 @@ exports[`AbstractAPI with mocked global.fetch commits.info({"branchId": "branch-
 Object {
   "fetch": Array [
     Array [
-      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?",
+      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?limit=1",
       Object {
         "headers": Object {
           "Abstract-Api-Version": "8",
@@ -576,7 +576,7 @@ exports[`AbstractAPI with mocked global.fetch commits.info({"branchId": "branch-
 Object {
   "fetch": Array [
     Array [
-      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?",
+      "https://api.goabstract.com/projects/project-id/branches/branch-id/commits?limit=1",
       Object {
         "headers": Object {
           "Abstract-Api-Version": "8",

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -362,15 +362,16 @@ export default class AbstractAPI implements AbstractInterface {
         | CommitDescriptor
         | LayerDescriptor
     ) => {
-      if (objectDescriptor.sha !== "latest") {
+      // Avoid using resolveDescriptor to prevent extra request
+      if (objectDescriptor.sha === "latest") {
+        const commits = await this.commits.list(objectDescriptor);
+        return commits[0];
+      } else {
         const commits = await this.commits.list(
           objectBranchDescriptor(objectDescriptor)
         );
 
         return find(commits, { sha: objectDescriptor.sha });
-      } else {
-        const commits = await this.commits.list(objectDescriptor);
-        return commits[0];
       }
     }
   };

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -362,7 +362,7 @@ export default class AbstractAPI implements AbstractInterface {
         | CommitDescriptor
         | LayerDescriptor
     ) => {
-      if (objectDescriptor.sha !== undefined) {
+      if (objectDescriptor.sha !== "latest") {
         const commits = await this.commits.list(
           objectBranchDescriptor(objectDescriptor)
         );

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -369,7 +369,7 @@ export default class AbstractAPI implements AbstractInterface {
       } else {
         const commits = await this.commits.list(
           objectBranchDescriptor(objectDescriptor),
-         { limit: 1 }
+          { limit: 1 }
         );
 
         return find(commits, { sha: objectDescriptor.sha });

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -364,11 +364,12 @@ export default class AbstractAPI implements AbstractInterface {
     ) => {
       // Avoid using resolveDescriptor to prevent extra request
       if (objectDescriptor.sha === "latest") {
-        const commits = await this.commits.list(objectDescriptor);
+        const commits = await this.commits.list(objectDescriptor, { limit: 1 });
         return commits[0];
       } else {
         const commits = await this.commits.list(
-          objectBranchDescriptor(objectDescriptor)
+          objectBranchDescriptor(objectDescriptor),
+         { limit: 1 }
         );
 
         return find(commits, { sha: objectDescriptor.sha });

--- a/src/AbstractAPI/test.js
+++ b/src/AbstractAPI/test.js
@@ -262,11 +262,21 @@ describe("AbstractAPI", () => {
       ],
       [
         "commits.info",
+        buildFileDescriptor({ sha: "latest" }),
+        { responses: [responses.commits.list()] }
+      ],
+      [
+        "commits.info",
         buildLayerDescriptor({ sha: "commit-sha" }),
         {
           responses: [responses.commits.info()],
           result: { sha: "commit-sha" }
         }
+      ],
+      [
+        "commits.info",
+        buildLayerDescriptor({ sha: "latest" }),
+        { responses: [responses.commits.list()] }
       ],
       // branches
       [

--- a/src/AbstractAPI/test.js
+++ b/src/AbstractAPI/test.js
@@ -244,6 +244,7 @@ describe("AbstractAPI", () => {
       ["commits.list", buildBranchDescriptor()],
       ["commits.list", buildFileDescriptor()],
       ["commits.list", buildLayerDescriptor()],
+      ["commits.info", buildCommitDescriptor()],
       [
         "commits.info",
         buildBranchDescriptor({ sha: "commit-sha" }),

--- a/src/AbstractCLI/__snapshots__/test.js.snap
+++ b/src/AbstractCLI/__snapshots__/test.js.snap
@@ -130,6 +130,8 @@ Object {
         "file-id",
         "--layer-id",
         "layer-id",
+        "--limit",
+        "1",
       ],
       Object {
         "cwd": "<PROJECT_ROOT>",
@@ -176,6 +178,8 @@ Object {
         "branch-id",
         "--file-id",
         "file-id",
+        "--limit",
+        "1",
       ],
       Object {
         "cwd": "<PROJECT_ROOT>",

--- a/src/AbstractCLI/__snapshots__/test.js.snap
+++ b/src/AbstractCLI/__snapshots__/test.js.snap
@@ -91,6 +91,100 @@ Object {
 }
 `;
 
+exports[`AbstractCLI with mocked child_process.spawn commits.info({"branchId": "branch-id", "fileId": "file-id", "layerId": "layer-id", "pageId": "page-id", "projectId": "project-id", "sha": "commit-sha"}) 1`] = `
+Object {
+  "spawn": Array [
+    Array [
+      "<PROJECT_ROOT>/fixtures/abstract-cli",
+      Array [
+        "--user-token",
+        "abstract-token",
+        "--api-url",
+        "https://api.goabstract.com",
+        "commit",
+        "project-id",
+        "commit-sha",
+      ],
+      Object {
+        "cwd": "<PROJECT_ROOT>",
+      },
+    ],
+  ],
+}
+`;
+
+exports[`AbstractCLI with mocked child_process.spawn commits.info({"branchId": "branch-id", "fileId": "file-id", "layerId": "layer-id", "pageId": "page-id", "projectId": "project-id", "sha": "latest"}) 1`] = `
+Object {
+  "spawn": Array [
+    Array [
+      "<PROJECT_ROOT>/fixtures/abstract-cli",
+      Array [
+        "--user-token",
+        "abstract-token",
+        "--api-url",
+        "https://api.goabstract.com",
+        "commits",
+        "project-id",
+        "branch-id",
+        "--file-id",
+        "file-id",
+        "--layer-id",
+        "layer-id",
+      ],
+      Object {
+        "cwd": "<PROJECT_ROOT>",
+      },
+    ],
+  ],
+}
+`;
+
+exports[`AbstractCLI with mocked child_process.spawn commits.info({"branchId": "branch-id", "fileId": "file-id", "projectId": "project-id", "sha": "commit-sha"}) 1`] = `
+Object {
+  "spawn": Array [
+    Array [
+      "<PROJECT_ROOT>/fixtures/abstract-cli",
+      Array [
+        "--user-token",
+        "abstract-token",
+        "--api-url",
+        "https://api.goabstract.com",
+        "commit",
+        "project-id",
+        "commit-sha",
+      ],
+      Object {
+        "cwd": "<PROJECT_ROOT>",
+      },
+    ],
+  ],
+}
+`;
+
+exports[`AbstractCLI with mocked child_process.spawn commits.info({"branchId": "branch-id", "fileId": "file-id", "projectId": "project-id", "sha": "latest"}) 1`] = `
+Object {
+  "spawn": Array [
+    Array [
+      "<PROJECT_ROOT>/fixtures/abstract-cli",
+      Array [
+        "--user-token",
+        "abstract-token",
+        "--api-url",
+        "https://api.goabstract.com",
+        "commits",
+        "project-id",
+        "branch-id",
+        "--file-id",
+        "file-id",
+      ],
+      Object {
+        "cwd": "<PROJECT_ROOT>",
+      },
+    ],
+  ],
+}
+`;
+
 exports[`AbstractCLI with mocked child_process.spawn commits.info({"branchId": "branch-id", "projectId": "project-id", "sha": "commit-sha"}) 1`] = `
 Object {
   "spawn": Array [

--- a/src/AbstractCLI/index.js
+++ b/src/AbstractCLI/index.js
@@ -188,15 +188,20 @@ export default class AbstractCLI implements AbstractInterface {
         | CommitDescriptor
         | LayerDescriptor
     ) => {
-      if (!objectDescriptor.sha) throw new Error("commits.info requires sha");
+      // Avoid using resolveDescriptor to prevent extra request
+      if (objectDescriptor.sha === "latest") {
+        const commits = await this.commits.list(objectDescriptor);
+        console.log('b', commits[0])
+        return commits[0];
+      } else {
+        const data = await this.spawn([
+          "commit",
+          objectDescriptor.projectId,
+          objectDescriptor.sha
+        ]);
 
-      const data = await this.spawn([
-        "commit",
-        objectDescriptor.projectId,
-        objectDescriptor.sha ? objectDescriptor.sha : "latest" // TODO latest
-      ]);
-
-      return data.commit;
+        return data.commit;
+      }
     }
   };
 

--- a/src/AbstractCLI/index.js
+++ b/src/AbstractCLI/index.js
@@ -190,7 +190,7 @@ export default class AbstractCLI implements AbstractInterface {
     ) => {
       // Avoid using resolveDescriptor to prevent extra request
       if (objectDescriptor.sha === "latest") {
-        const commits = await this.commits.list(objectDescriptor);
+        const commits = await this.commits.list(objectDescriptor, { limit: 1 });
         return commits[0];
       } else {
         const data = await this.spawn([

--- a/src/AbstractCLI/index.js
+++ b/src/AbstractCLI/index.js
@@ -191,7 +191,6 @@ export default class AbstractCLI implements AbstractInterface {
       // Avoid using resolveDescriptor to prevent extra request
       if (objectDescriptor.sha === "latest") {
         const commits = await this.commits.list(objectDescriptor);
-        console.log('b', commits[0])
         return commits[0];
       } else {
         const data = await this.spawn([

--- a/src/AbstractCLI/test.js
+++ b/src/AbstractCLI/test.js
@@ -38,6 +38,11 @@ const responses = {
       stdout: JSON.stringify({
         commits: [{ sha: "commit-sha" }, { sha: "next-commit-sha" }]
       })
+    }),
+    info: () => ({
+      stdout: JSON.stringify({
+        commit: { sha: "commit-sha" }
+      })
     })
   },
   files: {
@@ -137,6 +142,32 @@ describe(AbstractCLI, () => {
       ["commits.list", buildFileDescriptor()],
       ["commits.list", buildLayerDescriptor()],
       ["commits.info", buildCommitDescriptor()],
+      [
+        "commits.info",
+        buildFileDescriptor({ sha: "commit-sha" }),
+        {
+          responses: [responses.commits.info()],
+          result: { sha: "commit-sha" }
+        }
+      ],
+      [
+        "commits.info",
+        buildFileDescriptor({ sha: "latest" }),
+        { responses: [responses.commits.list()] }
+      ],
+      [
+        "commits.info",
+        buildLayerDescriptor({ sha: "commit-sha" }),
+        {
+          responses: [responses.commits.info()],
+          result: { sha: "commit-sha" }
+        }
+      ],
+      [
+        "commits.info",
+        buildLayerDescriptor({ sha: "latest" }),
+        { responses: [responses.commits.list()] }
+      ],
       // changesets
       ["changesets.info", buildCommitDescriptor()],
       // files


### PR DESCRIPTION
Noticed this as I started to build something with the sdk. This is a holdover from when sha could be `undefined` to represent "latest". No test for this so it was missed 🙈


