### PR TITLE
feature: add collections.update and collections.create to API transport

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -280,7 +280,7 @@ abstract.collections.info({
 
 ### Create a collection
 
-`collections.create(ProjectDescriptor, Collection): Promise<Collection>`
+`collections.create(ProjectDescriptor, NewCollection): Promise<Collection>`
 
 Create a new collection
 
@@ -296,7 +296,7 @@ abstract.collections.create({
 
 ### Update a collection
 
-`collections.update(CollectionDescriptor, Collection): Promise<Collection>`
+`collections.update(CollectionDescriptor, UpdatedCollection): Promise<Collection>`
 
 Update an existing collection
 

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -278,6 +278,37 @@ abstract.collections.info({
 });
 ```
 
+### Create a collection
+
+`collections.create(ProjectDescriptor, Collection): Promise<Collection>`
+
+Create a new collection
+
+```js
+abstract.collections.create({
+  projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78"
+}, {
+  name: "Test collection",
+  description: "Test description",
+  branchId: "c426d0a6-e039-43d7-b7b3-e685a25e4cfb"
+});
+```
+
+### Update a collection
+
+`collections.update(CollectionDescriptor, Collection): Promise<Collection>`
+
+Update an existing collection
+
+```js
+abstract.collections.update({
+  projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78",
+  collectionId: "413daa80-1456-11e8-b8b0-4d1fec7ae555"
+}, {
+  name: "New name"
+});
+```
+
 
 ## Comments
 

--- a/src/AbstractAPI/__snapshots__/test.js.snap
+++ b/src/AbstractAPI/__snapshots__/test.js.snap
@@ -233,6 +233,28 @@ Object {
 }
 `;
 
+exports[`AbstractAPI with mocked global.fetch collections.create([[Object], [Object]]) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/projects/project-id/collections",
+      Object {
+        "body": "{\\"body\\":{\\"name\\":\\"test-collection\\"}}",
+        "headers": Object {
+          "Abstract-Api-Version": "8",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+        "method": "POST",
+      },
+    ],
+  ],
+}
+`;
+
 exports[`AbstractAPI with mocked global.fetch collections.info({"branchId": "branch-id", "collectionId": "collection-id", "projectId": "project-id"}) 1`] = `
 Object {
   "fetch": Array [
@@ -287,6 +309,28 @@ Object {
           "User-Agent": "Abstract SDK 0.0",
           "X-Amzn-Trace-Id": "random-trace-id",
         },
+      },
+    ],
+  ],
+}
+`;
+
+exports[`AbstractAPI with mocked global.fetch collections.update([[Object], [Object]]) 1`] = `
+Object {
+  "fetch": Array [
+    Array [
+      "https://api.goabstract.com/projects/project-id/collections/collection-id",
+      Object {
+        "body": "{\\"body\\":{\\"name\\":\\"test-collection\\"}}",
+        "headers": Object {
+          "Abstract-Api-Version": "8",
+          "Accept": "application/json",
+          "Authorization": "Bearer abstract-token",
+          "Content-Type": "application/json",
+          "User-Agent": "Abstract SDK 0.0",
+          "X-Amzn-Trace-Id": "random-trace-id",
+        },
+        "method": "PUT",
       },
     ],
   ],

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -32,7 +32,8 @@ import type {
   AccessTokenOption,
   AccessToken,
   Activity,
-  Notification
+  Notification,
+  Collection
 } from "../types";
 import randomTraceId from "./randomTraceId";
 import Cursor from "./Cursor";
@@ -566,6 +567,35 @@ export default class AbstractAPI implements AbstractInterface {
 
       const data = await unwrapEnvelope(response.json());
       return data.collections[0];
+    },
+    create: async (
+      objectDescriptor: ProjectDescriptor,
+      collection: Collection
+    ) => {
+      const response = await this.fetch(
+        `projects/${objectDescriptor.projectId}/collections`,
+        {
+          method: "POST",
+          body: collection
+        }
+      );
+
+      return response.json();
+    },
+    update: async (
+      collectionDescriptor: CollectionDescriptor,
+      collection: Collection
+    ) => {
+      const response = await this.fetch(
+        // prettier-ignore
+        `projects/${collectionDescriptor.projectId}/collections/${collectionDescriptor.collectionId}`,
+        {
+          method: "PUT",
+          body: collection
+        }
+      );
+
+      return response.json();
     }
   };
 

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -33,7 +33,9 @@ import type {
   AccessToken,
   Activity,
   Notification,
-  Collection
+  Collection,
+  UpdatedCollection,
+  NewCollection
 } from "../types";
 import randomTraceId from "./randomTraceId";
 import Cursor from "./Cursor";
@@ -570,7 +572,7 @@ export default class AbstractAPI implements AbstractInterface {
     },
     create: async (
       objectDescriptor: ProjectDescriptor,
-      collection: Collection
+      collection: NewCollection
     ) => {
       const response = await this.fetch(
         `projects/${objectDescriptor.projectId}/collections`,
@@ -584,7 +586,7 @@ export default class AbstractAPI implements AbstractInterface {
     },
     update: async (
       collectionDescriptor: CollectionDescriptor,
-      collection: Collection
+      collection: UpdatedCollection
     ) => {
       const response = await this.fetch(
         // prettier-ignore

--- a/src/AbstractAPI/test.js
+++ b/src/AbstractAPI/test.js
@@ -198,6 +198,16 @@ describe("AbstractAPI", () => {
         buildCollectionDescriptor(),
         { responses: [responses.collections.list()] }
       ],
+      [
+        "collections.create",
+        [buildProjectDescriptor(), { body: { name: "test-collection" } }],
+        { responses: [responses.collections.info()] }
+      ],
+      [
+        "collections.update",
+        [buildCollectionDescriptor(), { body: { name: "test-collection" } }],
+        { responses: [responses.collections.info()] }
+      ],
       // comments
       [
         "comments.create",

--- a/src/types.js
+++ b/src/types.js
@@ -488,6 +488,19 @@ export type Collection = {
   layers: string[]
 };
 
+export type UpdatedCollection = {
+  name?: string,
+  description?: string,
+  published?: boolean
+};
+
+export type NewCollection = {
+  name: string,
+  branchId: string,
+  description?: string,
+  published?: boolean
+};
+
 export type Commit = {
   sha: string,
   projectId: string,
@@ -1346,8 +1359,8 @@ export interface AbstractInterface {
       options?: Object
     ) => Promise<Collection[]>,
     info: (CollectionDescriptor, options?: Object) => Promise<Collection>,
-    create?: (ProjectDescriptor, Collection) => Promise<Collection>,
-    update?: (CollectionDescriptor, Collection) => Promise<Collection>
+    create?: (ProjectDescriptor, NewCollection) => Promise<Collection>,
+    update?: (CollectionDescriptor, UpdatedCollection) => Promise<Collection>
   };
 
   comments?: {

--- a/src/types.js
+++ b/src/types.js
@@ -1345,7 +1345,9 @@ export interface AbstractInterface {
       ProjectDescriptor | BranchDescriptor,
       options?: Object
     ) => Promise<Collection[]>,
-    info: (CollectionDescriptor, options?: Object) => Promise<Collection>
+    info: (CollectionDescriptor, options?: Object) => Promise<Collection>,
+    create?: (ProjectDescriptor, Collection) => Promise<Collection>,
+    update?: (CollectionDescriptor, Collection) => Promise<Collection>
   };
 
   comments?: {


### PR DESCRIPTION
This pull request adds `collections.update` and `collections.create` endpoints to the API transport.

**Note:** I wasn't totally sure if there was value in exposing these on the API transport since retuned collections are only a subset of what is or can be returned from the CLI. Happy to close this PR if we should table this until full collections can be built using only the API. We still have #71 to handle the CLI side of this.

Resolves #70 