### PR TITLE
feature: add collections.update and collections.create to CLI transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
     "uuid": "^3.3.2"
   },
   "peerDependencies": {
-    "@elasticprojects/abstract-cli": "^0.31.0"
+    "@elasticprojects/abstract-cli": "^1.0.0"
   }
 }

--- a/src/AbstractCLI/__snapshots__/test.js.snap
+++ b/src/AbstractCLI/__snapshots__/test.js.snap
@@ -69,7 +69,7 @@ Object {
 }
 `;
 
-exports[`AbstractCLI with mocked child_process.spawn collections.info({"branchId": "branch-id", "collectionId": "collection-id", "projectId": "project-id"}) 1`] = `
+exports[`AbstractCLI with mocked child_process.spawn collections.create([[Object], [Object]]) 1`] = `
 Object {
   "spawn": Array [
     Array [
@@ -80,6 +80,30 @@ Object {
         "--api-url",
         "https://api.goabstract.com",
         "collection",
+        "create",
+        "project-id",
+        "--name",
+        "foo",
+      ],
+      Object {
+        "cwd": "<PROJECT_ROOT>",
+      },
+    ],
+  ],
+}
+`;
+
+exports[`AbstractCLI with mocked child_process.spawn collections.info({"branchId": "branch-id", "collectionId": "collection-id", "projectId": "project-id"}) 1`] = `
+Object {
+  "spawn": Array [
+    Array [
+      "<PROJECT_ROOT>/fixtures/abstract-cli",
+      Array [
+        "--user-token",
+        "abstract-token",
+        "--api-url",
+        "https://api.goabstract.com",
+        "collection load",
         "project-id",
         "collection-id",
       ],
@@ -126,6 +150,31 @@ Object {
         "https://api.goabstract.com",
         "collections",
         "project-id",
+      ],
+      Object {
+        "cwd": "<PROJECT_ROOT>",
+      },
+    ],
+  ],
+}
+`;
+
+exports[`AbstractCLI with mocked child_process.spawn collections.update([[Object], [Object]]) 1`] = `
+Object {
+  "spawn": Array [
+    Array [
+      "<PROJECT_ROOT>/fixtures/abstract-cli",
+      Array [
+        "--user-token",
+        "abstract-token",
+        "--api-url",
+        "https://api.goabstract.com",
+        "collection",
+        "update",
+        "project-id",
+        "collection-id",
+        "--name",
+        "foo",
       ],
       Object {
         "cwd": "<PROJECT_ROOT>",

--- a/src/AbstractCLI/__snapshots__/test.js.snap
+++ b/src/AbstractCLI/__snapshots__/test.js.snap
@@ -12,8 +12,8 @@ Object {
         "https://api.goabstract.com",
         "branch",
         "load",
-        "branch-id",
         "project-id",
+        "branch-id",
       ],
       Object {
         "cwd": "<PROJECT_ROOT>",

--- a/src/AbstractCLI/index.js
+++ b/src/AbstractCLI/index.js
@@ -16,7 +16,8 @@ import type {
   FileDescriptor,
   LayerDescriptor,
   CollectionDescriptor,
-  AccessTokenOption
+  AccessTokenOption,
+  Collection
 } from "../types";
 
 const logSpawn = log.extend("AbstractCLI:spawn");
@@ -316,10 +317,59 @@ export default class AbstractCLI implements AbstractInterface {
     },
     info: (collectionDescriptor: CollectionDescriptor) => {
       return this.spawn([
-        "collection",
+        "collection load",
         collectionDescriptor.projectId,
         collectionDescriptor.collectionId
       ]);
+    },
+    create: async (
+      projectDescriptor: ProjectDescriptor,
+      collection: Collection
+    ) => {
+      const name = collection.name ? ["--name", collection.name] : [];
+      const branchId = collection.branchId
+        ? ["--branchID", collection.branchId]
+        : [];
+      const description = collection.description
+        ? ["--description", collection.description]
+        : [];
+      const published = collection.published
+        ? ["--published", String(collection.published)]
+        : [];
+
+      const data = await this.spawn([
+        "collection",
+        "create",
+        projectDescriptor.projectId,
+        ...name,
+        ...branchId,
+        ...description,
+        ...published
+      ]);
+      return data.collection;
+    },
+    update: async (
+      collectionDescriptor: CollectionDescriptor,
+      collection: Collection
+    ) => {
+      const name = collection.name ? ["--name", collection.name] : [];
+      const description = collection.description
+        ? ["--description", collection.description]
+        : [];
+      const published = collection.published
+        ? ["--published", String(collection.published)]
+        : [];
+
+      const data = await this.spawn([
+        "collection",
+        "update",
+        collectionDescriptor.projectId,
+        collectionDescriptor.collectionId,
+        ...name,
+        ...description,
+        ...published
+      ]);
+      return data.collection;
     }
   };
 

--- a/src/AbstractCLI/index.js
+++ b/src/AbstractCLI/index.js
@@ -391,8 +391,8 @@ export default class AbstractCLI implements AbstractInterface {
       return await this.spawn([
         "branch",
         "load",
-        branchDescriptor.branchId,
-        branchDescriptor.projectId
+        branchDescriptor.projectId,
+        branchDescriptor.branchId
       ]);
     }
   };

--- a/src/AbstractCLI/test.js
+++ b/src/AbstractCLI/test.js
@@ -147,6 +147,8 @@ describe(AbstractCLI, () => {
       ["collections.list", buildProjectDescriptor()],
       ["collections.list", buildBranchDescriptor()],
       ["collections.info", buildCollectionDescriptor()],
+      ["collections.create", [buildProjectDescriptor(), { name: "foo" }]],
+      ["collections.update", [buildCollectionDescriptor(), { name: "foo" }]],
       // commits
       ["commits.list", buildBranchDescriptor()],
       ["commits.list", buildFileDescriptor()],

--- a/src/types.js
+++ b/src/types.js
@@ -485,6 +485,7 @@ export type Collection = {
   description: string,
   createdAt: string,
   publishedAt: string,
+  published: boolean,
   layers: string[]
 };
 
@@ -1345,7 +1346,9 @@ export interface AbstractInterface {
       ProjectDescriptor | BranchDescriptor,
       options?: Object
     ) => Promise<Collection[]>,
-    info: (CollectionDescriptor, options?: Object) => Promise<Collection>
+    info: (CollectionDescriptor, options?: Object) => Promise<Collection>,
+    create?: (ProjectDescriptor, Collection) => Promise<Collection>,
+    update?: (CollectionDescriptor, Collection) => Promise<Collection>
   };
 
   comments?: {


### PR DESCRIPTION
This pull request adds `collections.update` and `collections.create` endpoints to the CLI transport.

Requires https://github.com/goabstract/projects/pull/1288
Resolves #71 