### PR TITLE
bugfix: consolidate API and CLI collection data

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -236,7 +236,15 @@ abstract.changesets.info({
 
 A collection is a set of layers at the same or different commits on a branch, they can be created in the desktop or web app and are used to group work together to communicate a flow, ask for review, or other use cases.
 
-### The collection object
+### The collection page object
+
+| Property | Type | Description |
+| collections | Collection[] | Array of collections |
+| files | File[] | Array of files |
+| pages | Page[] | Array of pages |
+| layers | Layer[] | Array of layers |
+
+#### The collection object
 
 | Property      | Type                | Description                                                                             |
 |---------------|---------------------|-----------------------------------------------------------------------------------------|
@@ -253,7 +261,7 @@ A collection is a set of layers at the same or different commits on a branch, th
 
 ### List all collections
 
-`collections.list(ProjectDescriptor | BranchDescriptor, { layersPerCollection?: number }): Promise<Collection[]>`
+`collections.list(ProjectDescriptor | BranchDescriptor, { layersPerCollection?: number }): Promise<CollectionPage>`
 
 List all collections for a branch
 
@@ -266,7 +274,7 @@ abstract.collections.list({
 
 ### Retrieve a collection
 
-`collections.info(CollectionDescriptor): Promise<Collection>`
+`collections.info(CollectionDescriptor): Promise<CollectionPage>`
 
 Load an individual collection
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
     "uuid": "^3.3.2"
   },
   "peerDependencies": {
-    "@elasticprojects/abstract-cli": "^0.31.0"
+    "@elasticprojects/abstract-cli": "^1.0.0"
   }
 }

--- a/src/AbstractAPI/__snapshots__/test.js.snap
+++ b/src/AbstractAPI/__snapshots__/test.js.snap
@@ -276,7 +276,7 @@ exports[`AbstractAPI with mocked global.fetch collections.list({"branchId": "bra
 Object {
   "fetch": Array [
     Array [
-      "https://api.goabstract.com/projects/project-id/collections?branch_id=branch-id&layersPerCollection=4",
+      "https://api.goabstract.com/projects/project-id/collections?branch_id=branch-id",
       Object {
         "headers": Object {
           "Abstract-Api-Version": "8",
@@ -296,7 +296,7 @@ exports[`AbstractAPI with mocked global.fetch collections.list({"projectId": "pr
 Object {
   "fetch": Array [
     Array [
-      "https://api.goabstract.com/projects/project-id/collections?layersPerCollection=4",
+      "https://api.goabstract.com/projects/project-id/collections?",
       Object {
         "headers": Object {
           "Abstract-Api-Version": "8",

--- a/src/AbstractAPI/__snapshots__/test.js.snap
+++ b/src/AbstractAPI/__snapshots__/test.js.snap
@@ -256,7 +256,7 @@ exports[`AbstractAPI with mocked global.fetch collections.info({"branchId": "bra
 Object {
   "fetch": Array [
     Array [
-      "https://api.goabstract.com/projects/project-id/collections/collection-id?",
+      "https://api.goabstract.com/projects/project-id/collections/collection-id?layersPerCollection=all",
       Object {
         "headers": Object {
           "Abstract-Api-Version": "8",
@@ -276,7 +276,7 @@ exports[`AbstractAPI with mocked global.fetch collections.list({"branchId": "bra
 Object {
   "fetch": Array [
     Array [
-      "https://api.goabstract.com/projects/project-id/collections?branch_id=branch-id",
+      "https://api.goabstract.com/projects/project-id/collections?branch_id=branch-id&layersPerCollection=4",
       Object {
         "headers": Object {
           "Abstract-Api-Version": "8",
@@ -296,7 +296,7 @@ exports[`AbstractAPI with mocked global.fetch collections.list({"projectId": "pr
 Object {
   "fetch": Array [
     Array [
-      "https://api.goabstract.com/projects/project-id/collections?",
+      "https://api.goabstract.com/projects/project-id/collections?layersPerCollection=4",
       Object {
         "headers": Object {
           "Abstract-Api-Version": "8",

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -564,7 +564,9 @@ export default class AbstractAPI implements AbstractInterface {
   collections = {
     list: async (
       projectOrBranchDescriptor: ProjectDescriptor | BranchDescriptor,
-      options?: { layersPerCollection?: number | "all" } = {}
+      options?: { layersPerCollection?: number | "all" } = {
+        layersPerCollection: 4
+      }
     ) => {
       const query = queryString.stringify({
         branch_id: projectOrBranchDescriptor.branchId
@@ -578,12 +580,13 @@ export default class AbstractAPI implements AbstractInterface {
         `projects/${projectOrBranchDescriptor.projectId}/collections?${query}`
       );
 
-      const data = await unwrapEnvelope(response.json());
-      return data.collections;
+      return await unwrapEnvelope(response.json());
     },
     info: async (
       collectionDescriptor: CollectionDescriptor,
-      options?: { layersPerCollection?: number | "all" } = {}
+      options?: { layersPerCollection?: number | "all" } = {
+        layersPerCollection: "all"
+      }
     ) => {
       const query = queryString.stringify(options);
       const response = await this.fetch(
@@ -591,8 +594,7 @@ export default class AbstractAPI implements AbstractInterface {
         `projects/${collectionDescriptor.projectId}/collections/${collectionDescriptor.collectionId}?${query}`
       );
 
-      const data = await unwrapEnvelope(response.json());
-      return data.collections[0];
+      return await unwrapEnvelope(response.json());
     },
     create: async (
       objectDescriptor: ProjectDescriptor,

--- a/src/AbstractAPI/index.js
+++ b/src/AbstractAPI/index.js
@@ -564,9 +564,7 @@ export default class AbstractAPI implements AbstractInterface {
   collections = {
     list: async (
       projectOrBranchDescriptor: ProjectDescriptor | BranchDescriptor,
-      options?: { layersPerCollection?: number | "all" } = {
-        layersPerCollection: 4
-      }
+      options?: { layersPerCollection?: number | "all" } = {}
     ) => {
       const query = queryString.stringify({
         branch_id: projectOrBranchDescriptor.branchId

--- a/src/AbstractCLI/index.js
+++ b/src/AbstractCLI/index.js
@@ -16,7 +16,8 @@ import type {
   FileDescriptor,
   LayerDescriptor,
   CollectionDescriptor,
-  AccessTokenOption
+  AccessTokenOption,
+  File
 } from "../types";
 
 const logSpawn = log.extend("AbstractCLI:spawn");

--- a/src/types.js
+++ b/src/types.js
@@ -551,6 +551,18 @@ export type CollectionLayer = {
   order: number
 };
 
+export type File = {
+  applicationDocumentVersion: number,
+  applicationVersion: string,
+  id: string,
+  isLibrary: boolean,
+  lastChangedAtSha: string,
+  name: string,
+  projectId: string,
+  sha: string,
+  type: string
+};
+
 export type Collection = {
   id: string,
   userId: string,
@@ -1389,6 +1401,13 @@ export type CursorResponse<T> = {
   meta: CursorMeta
 };
 
+export type CollectionPage = {
+  collections: Collection[],
+  files: File[],
+  pages: Page[],
+  layers: Layer[]
+};
+
 export type AccessToken = ?string | ShareDescriptor;
 export type AccessTokenOption =
   | AccessToken // TODO: Deprecate?
@@ -1436,8 +1455,8 @@ export interface AbstractInterface {
     list: (
       ProjectDescriptor | BranchDescriptor,
       options?: Object
-    ) => Promise<Collection[]>,
-    info: (CollectionDescriptor, options?: Object) => Promise<Collection>,
+    ) => Promise<CollectionPage>,
+    info: (CollectionDescriptor, options?: Object) => Promise<CollectionPage>,
     create?: (ProjectDescriptor, NewCollection) => Promise<Collection>,
     update?: (CollectionDescriptor, UpdatedCollection) => Promise<Collection>
   };


### PR DESCRIPTION
This pull request fixes an issue where the CLI would return different data than the API for `collections` methods. The CLI was returning collections along with file data, so to maintain parity, the API also returns file data as well (though the file data will only be populated if the user opts-in to avoid a performance hit.)

Fixes #79