### PR TITLE
Embed Documentation

### DIFF
--- a/docs/embed.md
+++ b/docs/embed.md
@@ -1,0 +1,23 @@
+---
+id: embed
+title: Embed
+---
+
+> Note: Embed will only work for public layer shares
+
+Embed can be used to display the latest preview for an Abstract layer in your document or application.
+
+Given a public share url:
+
+`https://share.goabstract.com/b489311c-e7e9-4984-993b-0ff7df76396f`
+
+A embed can be created with an iframe at:
+
+`https://app.goabstract.com/embed/b489311c-e7e9-4984-993b-0ff7df76396f`
+
+
+```html
+<iframe src="https://app.goabstract.com/embed/b489311c-e7e9-4984-993b-0ff7df76396f"></iframe>
+```
+
+For now the display options are limited be we will be exploring more themes and options like collections in the near future


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38463/51781189-28b5da80-20ca-11e9-951c-1ab0bf0c3a36.png)

Would be nice to see if we can display an embed on this page. Maybe mdx? Docusaurus seems limited with its ability to handle embeds in markdown https://github.com/facebook/Docusaurus/issues/1165

Will explore a custom layout to see if that will work for now though
