### PR TITLE
feature: export Abstract.Error

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -4,12 +4,12 @@ import { log } from "./debug";
 const logAPIError = log.extend("AbstractAPI:status:error");
 const logCLIError = log.extend("AbstractCLI:status:error");
 
-type ErrorData = {|
+export type ErrorData = {|
   path: string,
   body: mixed
 |};
 
-class BaseError extends Error {
+export class BaseError extends Error {
   constructor(message: string) {
     super(message);
     this.name = this.constructor.name;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import client from "./Client";
 import * as Sketch from "./sketch";
 import * as TRANSPORTS from "./transports";
 import {
+  BaseError,
   ForbiddenError,
   InternalServerError,
   NotFoundError,
@@ -12,6 +13,7 @@ import {
 } from "./errors";
 
 const errors = {
+  Error: BaseError,
   ForbiddenError,
   InternalServerError,
   NotFoundError,


### PR DESCRIPTION
This pull request exports our base error class as `Abstract.Error` so it can be used downstream in `instanceof` checks. This prevents consumers from needing to build an intersection type of all of our errors for Flow and prevents runtime `Error.name` checks.