### PR TITLE
Introduce browserslistrc, ensure IE11 support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,9 +4,6 @@
     "@babel/preset-flow",
     ["@babel/preset-env", {
       "useBuiltIns": "usage",
-      "targets": {
-        "node": 8
-      },
       "exclude": ["transform-regenerator"]
     }]
   ],

--- a/src/.browserslistrc
+++ b/src/.browserslistrc
@@ -1,0 +1,11 @@
+and_chr >= 70
+ios_saf > 11
+last 5 firefox versions
+last 5 chrome versions
+ie 11
+last 3 safari versions
+last 3 edge versions
+op_mini all
+samsung >= 6.2
+and_uc >= 11.8
+node >= 8


### PR DESCRIPTION
Confirmed the compiled files no longer contain `class` references:

![image](https://user-images.githubusercontent.com/380914/52892799-ee7cad80-314a-11e9-969e-e1ffc54de092.png)

Related https://github.com/goabstract/ui/pull/475
Related https://github.com/goabstract/ui/pull/486