### PR TITLE
Remove publish step from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,4 @@ Changes and additions to the SDK should include tests and documentation updates 
 ```bash
 $ yarn version
 $ git push --follow-tags
-$ npm publish
 ```


### PR DESCRIPTION
Instructions were incorrect – the actual publish is done on CI, and always should be.