### PR TITLE
bugfix: add required runtime babel dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "readable-stream": "^3.0.3"
   },
   "dependencies": {
+    "@babel/runtime-corejs2": "^7.3.4",
     "JSONStream": "^1.3.4",
     "cross-fetch": "^2.2.2",
     "debug": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "query-string": "^6.1.0",
     "uuid": "^3.3.2"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "@elasticprojects/abstract-cli": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -667,6 +667,14 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
+"@babel/runtime-corejs2@^7.3.4":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.3.4.tgz#63f8bbc77622da202e9ea6f8f6e3bf28991832d9"
+  integrity sha512-QwPuQE65kNxjsNKk34Rfgen2R5fk0J2So99SD45uXBp34QOfyz11SqVgJ4xvyCpnCIieSQ0X0hSSc9z/ymlJJw==
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@^7.1.0", "@babel/template@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644"
@@ -1628,6 +1636,11 @@ core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
   integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
+
+core-js@^2.5.7:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
+  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -4858,6 +4871,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
 regenerator-transform@^0.13.3:
   version "0.13.3"


### PR DESCRIPTION
This pull request adds a runtime dependency on [`@babel/runtime-corejs2`](https://babeljs.io/docs/en/babel-runtime-corejs2), which includes both `@babel/runtime` and `core-js`. Both of these are required as runtime dependencies when using certain Babel functionality ([reference](https://github.com/babel/babel/issues/9134#issuecomment-447666617), [reference](https://github.com/babel/gulp-babel/issues/50#issuecomment-255606255)).

This also moves `@elasticprojects/abstract-cli` back to a `peerDependency` since Yarn can't ignore `optionalDependencies` yet ([reference](https://github.com/yarnpkg/yarn/issues/5366). This made it so the SDK was not installable externally when using Yarn.

Fixes https://github.com/goabstract/abstract-sdk/issues/101
Fixes https://github.com/goabstract/abstract-sdk/issues/102