### PR TITLE
Remove `pageId` from LayerDescriptor

### DIFF
--- a/src/endpoints/Comments.js
+++ b/src/endpoints/Comments.js
@@ -1,5 +1,10 @@
 // @flow
 import querystring from "query-string";
+import {
+  objectBranchDescriptor,
+  objectFileDescriptor,
+  layerPageDescriptor
+} from "../utils";
 import Cursor from "../Cursor";
 import type {
   BranchDescriptor,
@@ -7,7 +12,6 @@ import type {
   CommentDescriptor,
   CommitDescriptor,
   CursorPromise,
-  FileDescriptor,
   LayerDescriptor,
   ListOptions,
   NewComment,
@@ -29,47 +33,77 @@ export default class Comments extends Endpoint {
     }
     return this.request<Promise<Comment>>({
       api: async () => {
-        const branch = await this.client.branches.info({
-          branchId: descriptor.branchId,
-          projectId: descriptor.projectId
-        });
-        let commentData = {
-          branchName: branch.name
+        const branch = await this.client.branches.info(
+          objectBranchDescriptor(descriptor)
+        );
+
+        const body = {
+          ...descriptor,
+          commitSha: descriptor.sha || undefined,
+          branchName: branch.name,
+          annotation: comment.annotation,
+          body: comment.body
         };
+
         if (descriptor.layerId) {
-          const layer: any = await this.client.layers.info(descriptor);
-          commentData = {
-            ...commentData,
-            layerId: layer.id,
-            layerName: layer.name
-          };
-        }
-        if (descriptor.pageId) {
+          const layer = await this.client.layers.info(descriptor);
           const page = await this.client.pages.info(
-            ((descriptor: any): PageDescriptor)
+            layerPageDescriptor(layer, descriptor.branchId)
           );
+
           const file = await this.client.files.info(
-            ((descriptor: any): FileDescriptor)
+            objectFileDescriptor(descriptor)
           );
-          commentData = {
-            ...commentData,
-            fileId: file.id,
-            fileName: file.name,
-            fileType: file.type,
-            pageId: page.id,
-            pageName: page.name
-          };
+
+          return this.apiRequest("comments", {
+            method: "POST",
+            body: {
+              ...body,
+              fileName: file.name,
+              fileType: file.type,
+              pageId: page.id,
+              pageName: page.name,
+              layerName: layer.name
+            }
+          });
+        }
+
+        if (descriptor.pageId) {
+          const page = await this.client.pages.info(descriptor);
+          const file = await this.client.files.info(
+            objectFileDescriptor(descriptor)
+          );
+
+          return this.apiRequest("comments", {
+            method: "POST",
+            body: {
+              ...body,
+              fileName: file.name,
+              fileType: file.type,
+              pageId: page.id,
+              pageName: page.name
+            }
+          });
+        }
+
+        if (descriptor.fileId) {
+          const file = await this.client.files.info(
+            objectFileDescriptor(descriptor)
+          );
+
+          return this.apiRequest("comments", {
+            method: "POST",
+            body: {
+              ...body,
+              fileName: file.name,
+              fileType: file.type
+            }
+          });
         }
 
         return this.apiRequest("comments", {
           method: "POST",
-          body: {
-            ...commentData,
-            ...descriptor,
-            commitSha: descriptor.sha || undefined,
-            annotation: comment.annotation,
-            body: comment.body
-          }
+          body
         });
       }
     });

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -1,7 +1,6 @@
 // @flow
 import querystring from "query-string";
 import type {
-  ObjectDescriptor,
   Commit,
   CommitDescriptor,
   FileDescriptor,

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -1,7 +1,7 @@
 // @flow
 import querystring from "query-string";
 import type {
-  BaseCommitDescriptor,
+  ObjectDescriptor,
   Commit,
   CommitDescriptor,
   FileDescriptor,
@@ -67,9 +67,7 @@ export default class Commits extends Endpoint {
     });
   }
 
-  async getLatestDescriptor<T: BaseCommitDescriptor>(
-    descriptor: T
-  ): Promise<T> {
+  async getLatestDescriptor<T: ObjectDescriptor>(descriptor: T): Promise<T> {
     if (descriptor.sha !== "latest") return descriptor;
     const [commit] = await this.list((descriptor: any), { limit: 1 });
     return {

--- a/src/endpoints/Data.test.js
+++ b/src/endpoints/Data.test.js
@@ -11,7 +11,6 @@ describe("#info", () => {
       branchId: "branch-id",
       fileId: "file-id",
       layerId: "layer-id",
-      pageId: "page-id",
       projectId: "project-id",
       sha: "sha"
     });
@@ -27,7 +26,6 @@ describe("#info", () => {
       branchId: "branch-id",
       fileId: "file-id",
       layerId: "layer-id",
-      pageId: "page-id",
       projectId: "project-id",
       sha: "sha"
     });

--- a/src/endpoints/Descriptors.js
+++ b/src/endpoints/Descriptors.js
@@ -1,11 +1,9 @@
 // @flow
-import type { BaseCommitDescriptor } from "../types";
+import type { ObjectDescriptor } from "../types";
 import Endpoint from "./Endpoint";
 
 export default class Descriptors extends Endpoint {
-  async getLatestDescriptor<T: BaseCommitDescriptor>(
-    descriptor: T
-  ): Promise<T> {
+  async getLatestDescriptor<T: ObjectDescriptor>(descriptor: T): Promise<T> {
     if (descriptor.sha !== "latest") return descriptor;
     const [commit] = await this.client.commits.list((descriptor: any), {
       limit: 1

--- a/src/endpoints/Layers.test.js
+++ b/src/endpoints/Layers.test.js
@@ -13,7 +13,6 @@ describe("#info", () => {
       branchId: "branch-id",
       fileId: "file-id",
       layerId: "layer-id",
-      pageId: "page-id",
       projectId: "project-id",
       sha: "sha"
     });
@@ -29,7 +28,6 @@ describe("#info", () => {
       branchId: "branch-id",
       fileId: "file-id",
       layerId: "layer-id",
-      pageId: "page-id",
       projectId: "project-id",
       sha: "sha"
     });

--- a/src/endpoints/Previews.test.js
+++ b/src/endpoints/Previews.test.js
@@ -7,7 +7,6 @@ describe("#info", () => {
       branchId: "branch-id",
       fileId: "file-id",
       layerId: "layer-id",
-      pageId: "page-id",
       projectId: "project-id",
       sha: "sha"
     });

--- a/src/types.js
+++ b/src/types.js
@@ -25,8 +25,8 @@ export type NotificationDescriptor = {|
   notificationId: string
 |};
 
-export type BaseCommitDescriptor = {
-  sha: string,
+export type ObjectDescriptor = {
+  sha: "latest" | string,
   projectId: string,
   branchId: string | "master"
 };
@@ -43,17 +43,20 @@ export type BranchDescriptor = {|
 |};
 
 export type FileDescriptor = {|
-  ...CommitDescriptor,
+  ...$Exact<ObjectDescriptor>,
   fileId: string
 |};
 
 export type PageDescriptor = {|
-  ...FileDescriptor,
+  ...$Exact<ObjectDescriptor>,
+  fileId: string,
   pageId: string
 |};
 
 export type LayerDescriptor = {|
-  ...PageDescriptor,
+  ...$Exact<ObjectDescriptor>,
+  fileId: string,
+  pageId: string,
   layerId: string
 |};
 

--- a/src/types.js
+++ b/src/types.js
@@ -56,7 +56,6 @@ export type PageDescriptor = {|
 export type LayerDescriptor = {|
   ...$Exact<ObjectDescriptor>,
   fileId: string,
-  pageId: string,
   layerId: string
 |};
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,51 @@
 // @flow
-import type { ShareDescriptor } from "./types";
+import type {
+  CommitDescriptor,
+  BranchDescriptor,
+  FileDescriptor,
+  PageDescriptor,
+  LayerDescriptor,
+  ShareDescriptor,
+  Layer
+} from "./types";
+
+export function objectBranchDescriptor(
+  objectDescriptor:
+    | CommitDescriptor
+    | BranchDescriptor
+    | FileDescriptor
+    | PageDescriptor
+    | LayerDescriptor
+): BranchDescriptor {
+  return {
+    projectId: objectDescriptor.projectId,
+    branchId: objectDescriptor.branchId
+  };
+}
+
+export function objectFileDescriptor(
+  objectDescriptor: FileDescriptor | PageDescriptor | LayerDescriptor
+): FileDescriptor {
+  return {
+    projectId: objectDescriptor.projectId,
+    branchId: objectDescriptor.branchId,
+    fileId: objectDescriptor.fileId,
+    sha: objectDescriptor.sha
+  };
+}
+
+export function layerPageDescriptor(
+  layer: Layer,
+  branchId: string
+): PageDescriptor {
+  return {
+    projectId: layer.projectId,
+    branchId: branchId, // TODO: Expose branchId on Layer
+    fileId: layer.fileId,
+    pageId: layer.pageId,
+    sha: layer.sha
+  };
+}
 
 export default function parseShareURL(url: string): ?string {
   return url.split("share.goabstract.com/")[1];


### PR DESCRIPTION
For https://github.com/goabstract/abstract-sdk/issues/76

- Revert descriptor types back to explicitly defined types. I originally avoided spread because I assumed the object descriptors wouldn't always be perfectly hierarchical like with the absence of pageId
- Added utility functions back to help explicitly convert objects into exact descriptors to avoid usage of `any`
- Added new utility for converting layer into `PageDescriptor` for commenting
- Updated `comments.create` so that when commenting on a layer `pageId` is loaded from the layer
- Remove `pageId` from `LayerDescriptor`

