### PR TITLE
feature: deploy documentation on branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ workflows:
             - test
           filters:
             branches:
-              only: master
+              only: docs
       - publish:
           <<: *tagged
           requires:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Changes and additions to the SDK should include tests and documentation updates 
 ## Publishing
 
 ```bash
+$ git rebase docs
 $ yarn version
 $ git push --follow-tags
 $ npm publish


### PR DESCRIPTION
This pull request updates the the continuous integration script so that documentation is only deployed on pushes to the `docs` branch. This will allow documentation updates independently of `master` pushes or any release (NPM, git, or otherwise.) Note that this requires one extra step when cutting a new release: rebasing `master` on top of `docs` to pick up any typo fixes or changes made directly against the `docs` branch.

Resolves #62