### PR TITLE
feature: update README and add CONTRIBUTING guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -45,17 +45,17 @@ threatening, offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
 
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project team at support@abstract.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -74,3 +74,4 @@ available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.ht
 
 For answers to common questions about this code of conduct, see
 https://www.contributor-covenant.org/faq
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing to the Abstract SDK
+
+We're very grateful for outside contributions, as they both improve the robustness of the SDK and help inform how the SDK is being used in real-world applications. Whether the contribution is a minor documentation fix or major feature enhancement, we're always happy to accept changes that adhere to the expectations in this document.
+
+## Code of conduct
+
+Please note that this project adheres to a [code of conduct](https://github.com/goabstract/abstract-sdk/blob/master/CODE_OF_CONDUCT.md).
+
+## Submitting an issue
+
+Please follow the provided template when [submitting an issue](https://github.com/goabstract/abstract-sdk/issues/new).
+
+## Submitting a pull request
+
+Please follow the provided template when [submitting a pull request](https://github.com/goabstract/abstract-sdk/compare).
+
+## Local development
+
+The SDK codebase is written using modern JavaScript language features and is statically-typed using Flow. The commands below (and repository as a whole) use Yarn, but both Yarn and NPM can be used interchangeably depending on developer preference.
+
+### Setup
+
+Fork and clone the repository:
+
+```sh
+$ git clone https://github.com/<username>/abstract-sdk
+```
+
+### Installation
+
+Install dependencies from the project root using Yarn:
+
+```sh
+$ cd abstract-sdk && yarn
+```
+
+### Compilation
+
+Type-check all code using Flow:
+
+```sh
+yarn flow
+```
+
+### Building
+
+Transpile the `src` directory into a `lib` directory using Babel:
+
+```sh
+yarn build
+```
+
+### Linting
+
+Lint an format all code using Prettier via ESLint:
+
+```sh
+yarn lint --fix
+```
+
+### Testing
+
+Run unit tests using Jest:
+
+```sh
+yarn test
+```
+
+## Documentation
+
+Both the documentation content and its static website code live inside this repository in the [`docs`](https://github.com/goabstract/abstract-sdk/tree/master/docs) and [`website`](https://github.com/goabstract/abstract-sdk/tree/master/website) folders, respectively. The documentation auto-deploys to [https://sdk.goabstract.com](https://sdk.goabstract.com) whenever new commits occur on the [`docs`](https://github.com/goabstract/abstract-sdk/tree/docs) branch. This means that **pull requests to update documentation should be made against the `docs` branch** instead of `master`.
+
+### Installation
+
+Install dependencies from the `/website` folder using Yarn:
+
+```sh
+cd website && yarn
+```
+
+### Running
+
+Serve the documentation site at [http://localhost:3000](http://localhost:3000):
+
+```sh
+yarn start
+```
+
+## Cutting releases
+
+New package versions of `abstract-sdk` are automatically published to the public NPM registry whenever new tags are pushed to the repository. Be sure to rebase `master` on top of `docs` to pick up any documentation hotfixes made between versions.
+
+```sh
+$ git checkout docs
+$ git pull --rebase origin docs
+$ git checkout master
+$ git rebase docs
+$ yarn version
+$ git push --follow-tags
+```
+
+<br />
+<br />
+<br />
+<br />
+<img src="https://www.abstract.com/wp-content/uploads/abstract-black-wordmark-rgb.png" width="136" height="auto" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ yarn build
 
 ### Linting
 
-Lint an format all code using Prettier via ESLint:
+Lint and format all code using Prettier via ESLint:
 
 ```sh
 yarn lint --fix

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following community resources are available to help you get started quickly 
 
 ## Contributing
 
-This project is maintained by a team at [Abstract](https://www.abstract.com). Outside contributions are highly encouraged, but please ensure that a relevant [issue](https://github.com/goabstract/abstract-sdk/issues) exists and that an approach has been discussed before begining to write code. This makes it more likely that your contribution will be accepted and ensures that your time is not wasted.
+This project is maintained by a team at [Abstract](https://www.abstract.com). Outside contributions are highly encouraged, but please ensure that a relevant [issue](https://github.com/goabstract/abstract-sdk/issues) exists and that an approach has been discussed before beginning to write code. This makes it more likely that your contribution will be accepted and ensures that your time is not wasted.
 
 Please see the [contributors guide](/blob/master/CONTRIBUTING.md) for more information.
 

--- a/README.md
+++ b/README.md
@@ -1,44 +1,38 @@
-[![npm version](https://badge.fury.io/js/abstract-sdk.svg)](https://badge.fury.io/js/abstract-sdk) [![CircleCI](https://circleci.com/gh/goabstract/abstract-sdk.svg?style=svg)](https://circleci.com/gh/goabstract/abstract-sdk)
+<img src="https://www.abstract.com/wp-content/uploads/abstract-black-wordmark-rgb.png" width="136" height="auto" />
 
-# Abstract SDK
+The Abstract SDK provides universal JavaScript bindings for both the Abstract API and the Abstract CLI.
 
-This library provides a universal javascript binding for the Abstract API and CLI.
+[![build status](https://img.shields.io/circleci/project/github/goabstract/abstract-sdk.svg)](https://circleci.com/gh/goabstract/abstract-sdk)
+[![npm version](https://badge.fury.io/js/abstract-sdk.svg)](https://www.npmjs.com/package/abstract-sdk)
+
+## Installation
+
+The SDK is available as a Node.js module available via the public NPM registry. An underlying Node.js version of `8.0.0` or higher is required.
+
+```sh
+npm install abstract-sdk
+```
+
+Please see the [installation guide](https://sdk.goabstract.com/docs/installation/) for more information.
 
 ## Documentation
 
-Check out the [Getting Started](https://sdk.goabstract.com/docs/installation/) page for a quick overview.
+Complete SDK documentation can be found at [https://sdk.goabstract.com](https://sdk.goabstract.com).
 
-For full documentation please visit:
+The following community resources are available to help you get started quickly with the SDK:
 
-https://sdk.goabstract.com
-
-Help improve documentation by clicking the "Edit" button on any page or by creating as pull request.
-
-## Development
-
-Start the test runner with the `--watch` option. The SDK uses jest's snapshot testing to document calls to the api and cli.
-
-```bash
-$ yarn test --watch
-```
-
-*In the event of a snapshot change, jest will guide you through comparing and updating the snapshot.*
+- [Documentation website](https://sdk.goabstract.com)
+- [Spectrum chat](https://spectrum.chat/abstract)
+- [Abstract help center](https://www.abstract.com/help/)
+- [Abstract support](https://www.abstract.com/help/contact/)
+- Still stuck? [File an issue!](https://github.com/goabstract/abstract-sdk/issues/new)
 
 ## Contributing
 
-This project is maintained by a team at [Abstract](https://www.goabstract.com). We are very willing to accept contributions, first please ensure there is a relavant [issue in the tracker](https://github.com/goabstract/abstract-sdk/issues) and an approach has been discussed before beginning to write code – this makes it more likely we will be able to accept your contribution and ensure nobody's time (especially yours!) is wasted.
+This project is maintained by a team at [Abstract](https://www.abstract.com). Outside contributions are highly encouraged, but please ensure that a relevant [issue](https://github.com/goabstract/abstract-sdk/issues) exists and that an approach has been discussed before begining to write code. This makes it more likely that your contribution will be accepted and ensures that your time is not wasted.
 
-Changes and additions to the SDK should include tests and documentation updates as part of the pull request.
+Please see the [contributors guide](/blob/master/CONTRIBUTING.md) for more information.
 
-### Tests
+## License
 
-
-
-## Publishing
-
-```bash
-$ git rebase docs
-$ yarn version
-$ git push --follow-tags
-$ npm publish
-```
+[MIT](/blob/master/LICENSE.md)


### PR DESCRIPTION
This pull request updates the `README` and adds a simple `CONTRIBUTING` guide. It's mostly a reorganization of existing information (moving contribution-specific content to a contributor-specific file to keep the `README` simple) with a few corrections after recent changes.