### PR TITLE
bugfix: remove email addresses from documentation and type interfaces

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -750,7 +750,6 @@ Organizations contain users and projects.
 
 | Property                   | Type       | Description                                                                              |
 |----------------------------|------------|------------------------------------------------------------------------------------------|
-| `billingEmail`             | `string`   | Billing email associated with this organization                                          |
 | `features`                 | `{[feature: string]: boolean}` | Map of feature flags enabled for this organization                   |
 | `hasBillingInfo`           | `boolean`  | Whether this organization has billing information on file                                |
 | `id`                       | `string`   | UUID                                                                                     |
@@ -1041,7 +1040,6 @@ A user contains information specific to an individual account. Users are global 
 | `avatarUrl`       | `string` | URL of the avatar for this user                              |
 | `createdAt`       |  `string`| Timestamp indicating when this account was created           |
 | `deletedAt`       | `string` | Timestamp indicating when this account was deleted           |
-| `email`           | `string` | Email associated with this user account                      |
 | `id`              | `string` | UUID identifier for the user                                 |
 | `name`            | `string` | The name of the page                                         |
 | `primaryEmailId`  | `string` | ID of the primary email for this user                        |

--- a/src/types.js
+++ b/src/types.js
@@ -318,7 +318,6 @@ export type Activity =
 
 export type User = {
   id: string,
-  email: string,
   primaryEmailId: string,
   createdAt: string,
   updatedAt: string,
@@ -329,7 +328,6 @@ export type User = {
 };
 
 export type Organization = {
-  billingEmail?: string,
   features: { [feature: string]: boolean },
   hasBillingInfo?: boolean,
   id: string,


### PR DESCRIPTION
This pull request updates the SDK documentation and external type interfaces by removing references to both `email` and `billingEmail`. Both of these fields will no longer be returned by the API.