### PR TITLE
feature: add memberships endpoint to the API transport

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -722,7 +722,7 @@ abstract.memberships.list({
 
 ### Retrieve a membership
 
-`memberships.info(MembershipDescriptor): Promise<Membership>`
+`memberships.info(OrganizationMembershipDescriptor | ProjectMembershipDescriptor): Promise<Membership>`
 
 Load the info for a specific member
 
@@ -1235,12 +1235,20 @@ Reference for the parameters required to load resources with Abstract SDK.
 }
 ```
 
-### MembershipDescriptor
+### OrganizationProjectDescriptor
+
+```js
+{
+  projectId?: string,
+  userId: string
+}
+```
+
+### ProjectMembershipDescriptor
 
 ```js
 {
   organizationId?: string,
-  projectId?: string,
   userId: string
 }
 ```

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -691,6 +691,49 @@ abstract.layers.info({
 ```
 
 
+## Memberships
+
+A membership contains information about a user's role within an organization or a project. A membership is created when a user joins an organization or is given access to a project.
+
+![API][api-icon]
+
+### The membership object
+
+| Property          | Type     | Description                                                  |
+|-------------------|----------|--------------------------------------------------------------|
+| `createdAt`       | `string` | Timestamp indicating when this membership was created        |
+| `organizationId`  | `string` | UUID of the organization this membership belongs to          |
+| `projectId`       | `string` | UUID of the project this membership belongs to               |
+| `role`            | `string` | Type of this membership                                      |
+| `userId`          | `string` | UUID of the user that this membership represents             |
+| `user`            | `User`   | The user that this membership represents                     |
+
+### List all memberships
+
+`memberships.list(OrganizationDescriptor | ProjectDescriptor): Promise<Membership[]>`
+
+List the members of an organization
+
+```js
+abstract.memberships.list({
+  organizationId: "d147fba5-c713-4fb9-ab16-e7e82ed9cbc9"
+});
+```
+
+### Retrieve a membership
+
+`memberships.info(MembershipDescriptor): Promise<Membership>`
+
+Load the info for a specific member
+
+```js
+abstract.memberships.info({
+  userId: "48b5d670-2002-45ea-929d-4b00863778e4",
+  organizationId: "d147fba5-c713-4fb9-ab16-e7e82ed9cbc9"
+});
+```
+
+
 ## Notifications
 
 ![API][api-icon]
@@ -1189,5 +1232,15 @@ Reference for the parameters required to load resources with Abstract SDK.
 {
   assetId: string,
   projectId: string
+}
+```
+
+### MembershipDescriptor
+
+```js
+{
+  organizationId?: string,
+  projectId?: string,
+  userId: string
 }
 ```

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -1239,7 +1239,7 @@ Reference for the parameters required to load resources with Abstract SDK.
 
 ```js
 {
-  projectId?: string,
+  projectId: string,
   userId: string
 }
 ```
@@ -1248,7 +1248,7 @@ Reference for the parameters required to load resources with Abstract SDK.
 
 ```js
 {
-  organizationId?: string,
+  organizationId: string,
   userId: string
 }
 ```

--- a/src/Client.js
+++ b/src/Client.js
@@ -12,6 +12,7 @@ import Descriptors from "./endpoints/Descriptors";
 import Endpoint from "./endpoints/Endpoint";
 import Files from "./endpoints/Files";
 import Layers from "./endpoints/Layers";
+import Memberships from "./endpoints/Memberships";
 import Notifications from "./endpoints/Notifications";
 import Organizations from "./endpoints/Organizations";
 import Pages from "./endpoints/Pages";
@@ -33,6 +34,7 @@ export default class Client {
   descriptors: Descriptors;
   files: Files;
   layers: Layers;
+  memberships: Memberships;
   notifications: Notifications;
   organizations: Organizations;
   pages: Pages;
@@ -66,6 +68,7 @@ export default class Client {
     this.descriptors = new Descriptors(this, options);
     this.files = new Files(this, options);
     this.layers = new Layers(this, options);
+    this.memberships = new Memberships(this, options);
     this.notifications = new Notifications(this, options);
     this.organizations = new Organizations(this, options);
     this.pages = new Pages(this, options);

--- a/src/endpoints/Memberships.js
+++ b/src/endpoints/Memberships.js
@@ -1,14 +1,17 @@
 // @flow
 import type {
   Membership,
-  MembershipDescriptor,
   OrganizationDescriptor,
-  ProjectDescriptor
+  OrganizationMembershipDescriptor,
+  ProjectDescriptor,
+  ProjectMembershipDescriptor
 } from "../types";
 import Endpoint from "./Endpoint";
 
 export default class Users extends Endpoint {
-  info(descriptor: MembershipDescriptor): Promise<Membership> {
+  info(
+    descriptor: OrganizationMembershipDescriptor | ProjectMembershipDescriptor
+  ): Promise<Membership> {
     return this.request<Promise<Membership>>({
       api: async () => {
         let url = "";

--- a/src/endpoints/Memberships.js
+++ b/src/endpoints/Memberships.js
@@ -1,0 +1,46 @@
+// @flow
+import type {
+  Membership,
+  MembershipDescriptor,
+  OrganizationDescriptor,
+  ProjectDescriptor
+} from "../types";
+import Endpoint from "./Endpoint";
+
+export default class Users extends Endpoint {
+  info(descriptor: MembershipDescriptor): Promise<Membership> {
+    return this.request<Promise<Membership>>({
+      api: async () => {
+        let url = "";
+        if (descriptor.organizationId) {
+          url = `organizations/${descriptor.organizationId}/memberships/${
+            descriptor.userId
+          }`;
+        } else if (descriptor.projectId) {
+          url = `projects/${descriptor.projectId}/memberships/${
+            descriptor.userId
+          }`;
+        }
+        const response = await this.apiRequest(url);
+        return response.data.projectMembership || response.data;
+      }
+    });
+  }
+
+  list(
+    descriptor: OrganizationDescriptor | ProjectDescriptor
+  ): Promise<Membership[]> {
+    return this.request<Promise<Membership[]>>({
+      api: async () => {
+        let url = "";
+        if (descriptor.organizationId) {
+          url = `organizations/${descriptor.organizationId}/memberships`;
+        } else if (descriptor.projectId) {
+          url = `projects/${descriptor.projectId}/memberships`;
+        }
+        const response = await this.apiRequest(url);
+        return response.data;
+      }
+    });
+  }
+}

--- a/src/endpoints/Memberships.test.js
+++ b/src/endpoints/Memberships.test.js
@@ -1,0 +1,58 @@
+// @flow
+import { mockAPI, API_CLIENT } from "../testing";
+
+describe("#info", () => {
+  test("api - project", async () => {
+    mockAPI("/projects/project-id/memberships/user-id", {
+      data: {
+        projectMembership: { userId: "user-id" }
+      }
+    });
+
+    const response = await API_CLIENT.memberships.info({
+      projectId: "project-id",
+      userId: "user-id"
+    });
+
+    expect(response).toEqual({ userId: "user-id" });
+  });
+
+  test("api - organization", async () => {
+    mockAPI("/organizations/org-id/memberships/user-id", {
+      data: { userId: "user-id" }
+    });
+
+    const response = await API_CLIENT.memberships.info({
+      organizationId: "org-id",
+      userId: "user-id"
+    });
+
+    expect(response).toEqual({ userId: "user-id" });
+  });
+});
+
+describe("#list", () => {
+  test("api - project", async () => {
+    mockAPI("/projects/project-id/memberships", {
+      data: [{ userId: "user-id" }]
+    });
+
+    const response = await API_CLIENT.memberships.list({
+      projectId: "project-id"
+    });
+
+    expect(response).toEqual([{ userId: "user-id" }]);
+  });
+
+  test("api - organization", async () => {
+    mockAPI("/organizations/org-id/memberships", {
+      data: [{ userId: "user-id" }]
+    });
+
+    const response = await API_CLIENT.memberships.list({
+      organizationId: "org-id"
+    });
+
+    expect(response).toEqual([{ userId: "user-id" }]);
+  });
+});

--- a/src/types.js
+++ b/src/types.js
@@ -340,10 +340,6 @@ export type OrganizationMembershipDescriptor = {|
   organizationId: string
 |};
 
-export type MembershipDescriptor =
-  | ProjectMembershipDescriptor
-  | OrganizationMembershipDescriptor;
-
 export type Membership = {
   createdAt: string,
   organizationId?: string,

--- a/src/types.js
+++ b/src/types.js
@@ -328,21 +328,19 @@ export type User = {
   avatarUrl: string
 };
 
-export type MembershipDescriptorBase = {| userId: string |};
-
 export type ProjectMembershipDescriptor = {|
-  ...$Exact<MembershipDescriptorBase>,
+  userId: string,
   projectId: string
 |};
 
 export type OrganizationMembershipDescriptor = {|
-  ...$Exact<MembershipDescriptorBase>,
+  userId: string,
   organizationId: string
 |};
 
 export type Membership = {
   createdAt: string,
-  organizationId?: string,
+  organizationId: string,
   projectId?: string,
   role: string,
   user: User,

--- a/src/types.js
+++ b/src/types.js
@@ -328,6 +328,31 @@ export type User = {
   avatarUrl: string
 };
 
+export type MembershipDescriptorBase = {| userId: string |};
+
+export type ProjectMembershipDescriptor = {|
+  ...$Exact<MembershipDescriptorBase>,
+  projectId: string
+|};
+
+export type OrganizationMembershipDescriptor = {|
+  ...$Exact<MembershipDescriptorBase>,
+  organizationId: string
+|};
+
+export type MembershipDescriptor =
+  | ProjectMembershipDescriptor
+  | OrganizationMembershipDescriptor;
+
+export type Membership = {
+  createdAt: string,
+  organizationId?: string,
+  projectId?: string,
+  role: string,
+  user: User,
+  userId: string
+};
+
 export type Organization = {
   billingEmail?: string,
   features: { [feature: string]: boolean },


### PR DESCRIPTION
This pull request adds a new `Memberships` endpoint with API transport support.

Requires https://github.com/goabstract/projects/pull/1977
References #108
