### PR TITLE
bugfix: remove abstract-cli dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,5 @@
     "flow-typed": "^2.5.1",
     "query-string": "^6.1.0",
     "uuid": "^3.3.2"
-  },
-  "peerDependencies": {
-    "@elasticprojects/abstract-cli": "^1.0.0"
   }
 }


### PR DESCRIPTION
This pull request removes `abstract-cli` from the dependency list since this is only sort of useful for internal SDK usage (and even then, a custom `cliPath` is almost always used.) This also allows the SDK to be externally installed without skipping peer or optional dependencies, which was reported via support.