### PR TITLE
bugfix: use lastChangedAtSha for latest preview requests

### DIFF
--- a/src/endpoints/Descriptors.js
+++ b/src/endpoints/Descriptors.js
@@ -5,13 +5,32 @@ import Endpoint from "./Endpoint";
 export default class Descriptors extends Endpoint {
   async getLatestDescriptor<T: ObjectDescriptor>(descriptor: T): Promise<T> {
     if (descriptor.sha !== "latest") return descriptor;
+
     const [commit] = await this.client.commits.list((descriptor: any), {
       limit: 1
     });
-    return {
+
+    let latestDescriptor: any = {
       ...descriptor,
       commitSha: commit.sha,
       sha: commit.sha
     };
+
+    if (
+      latestDescriptor.projectId &&
+      latestDescriptor.branchId &&
+      latestDescriptor.sha &&
+      latestDescriptor.fileId &&
+      latestDescriptor.layerId
+    ) {
+      const layer = await this.client.layers.info(latestDescriptor);
+      latestDescriptor = {
+        ...descriptor,
+        commitSha: layer.lastChangedAtSha,
+        sha: layer.lastChangedAtSha
+      };
+    }
+
+    return latestDescriptor;
   }
 }


### PR DESCRIPTION
This pull request brings the SDK up to parity with the desktop and web applications with how they render layer preview images. Specifically, the applications default to `layer.lastChangedAtSha`, whereas the SDK was defaulting to the latest layer commit's `sha`. We noticed a timing issue when using the SDK's approach; some embeds would appear broken because the latest commit's `sha` didn't yet have a preview image generated. Later in the day, with no changes, they started to work.

For now, so the SDK matches the application exactly, we're using `layer.lastChangedAtSha` for latest preview requests.

Fixes https://goabstract.atlassian.net/browse/PLATFORM-273