### PR TITLE
feature: add files.raw to the CLI transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v1.4.0
+- Added missing `LayerDataset` type
+- Upgraded shares endpoint to API v13 with native `latest` resolution
+
+## v1.3.0
+- Updated CI documentation
+- Added entity cache
+- Removed `abstract-cli` dependency
+
 ## v1.2.0
 - Updated type interfaces to no longer include email addresses
 - Added `memberships.list` and `memberships.info` to the API transport

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -9,8 +9,6 @@ title: Client
 
 ## Activities
 
-![API][api-icon]
-
 An activity represents a designated type of event within a project. These events can be specific to the project itself, or they can be specific to a collection, a branch, a commit, or a review within the project.
 
 ### The activity object
@@ -26,6 +24,8 @@ An activity represents a designated type of event within a project. These events
 
 ### List all activities
 
+![API][api-icon]
+
 `activities.list(BranchDescriptor | OrganizationDescriptor | ProjectDescriptor, { limit?: number, offset?: number }): Promise<Activity[]>`
 
 List the first two activities for a given project on a specific branch
@@ -38,6 +38,8 @@ abstract.activities.list({
 ```
 
 ### Retrieve an activity
+
+![API][api-icon]
 
 `activities.info(ActivityDescriptor): Promise<Activity>`
 
@@ -55,8 +57,6 @@ abstract.activities.info({
 
 
 ## Assets
-
-![API][api-icon]
 
 An asset represents a resource exported from a design file. Assets are automatically updated and available for new commits.
 
@@ -83,6 +83,8 @@ An asset represents a resource exported from a design file. Assets are automatic
 
 ### List all assets
 
+![API][api-icon]
+
 `assets.list(BranchDescriptor): Promise<Asset[]>`
 
 List all assets for a commit on a given branch of a project
@@ -97,6 +99,8 @@ abstract.assets.list({
 
 ### Retrieve an asset
 
+![API][api-icon]
+
 `asset.info(AssetDescriptor): Promise<Asset>`
 
 Load the info for an asset
@@ -109,6 +113,8 @@ abstract.assets.info({
 ```
 
 ### Retrieve an asset file
+
+![API][api-icon]
 
 `asset.raw(AssetDescriptor, { filename?: string, disableWrite?: boolean }): Promise<ArrayBuffer>`
 
@@ -142,8 +148,6 @@ fs.writeFile("asset.png", Buffer.from(processedBuffer), (err) => {
 
 ## Branches
 
-![CLI][cli-icon] ![API][api-icon]
-
 A branch is where design work and commits happen. A branch acts as a personal workspace for contributors, we encourage branches
 to be created for logical chunks of work – for example designing a new feature.
 
@@ -169,6 +173,8 @@ to be created for logical chunks of work – for example designing a new feature
 
 ### List all branches
 
+![CLI][cli-icon] ![API][api-icon]
+
 `branches.list(ProjectDescriptor, { filter?: "active" | "archived" | "mine" }): Promise<Branch[]>`
 
 List the active branches for a project
@@ -183,6 +189,8 @@ abstract.branches.list({
 
 ### Retrieve a branch
 
+![CLI][cli-icon] ![API][api-icon]
+
 `branches.info(BranchDescriptor): Promise<Branch>`
 
 Load the info for a specific branch in a project
@@ -196,8 +204,6 @@ abstract.branches.info({
 
 
 ## Changesets
-
-![CLI][cli-icon] ![API][api-icon]
 
 A changeset is a group of changes that together form a single, indivisible modification to a project. Changesets include data on all visual and nonvisual changes and provide insight into the differences between two versions of a project.
 
@@ -230,6 +236,8 @@ A changeset is a group of changes that together form a single, indivisible modif
 
 ### Retrieve a changeset
 
+![CLI][cli-icon] ![API][api-icon]
+
 `changesets.info(CommitDescriptor): Promise<Changeset>`
 
 Load an individual changeset
@@ -244,8 +252,6 @@ abstract.changesets.info({
 
 
 ## Collections
-
-![CLI][cli-icon] ![API][api-icon]
 
 A collection is a set of layers at the same or different commits on a branch, they can be created in the desktop or web app and are used to group work together to communicate a flow, ask for review, or other use cases.
 
@@ -274,6 +280,8 @@ A collection is a set of layers at the same or different commits on a branch, th
 
 ### List all collections
 
+![CLI][cli-icon] ![API][api-icon]
+
 `collections.list(ProjectDescriptor | BranchDescriptor, { layersPerCollection?: number }): Promise<CollectionPage>`
 
 List all collections for a branch
@@ -286,6 +294,8 @@ abstract.collections.list({
 ```
 
 ### Retrieve a collection
+
+![CLI][cli-icon] ![API][api-icon]
 
 `collections.info(CollectionDescriptor): Promise<CollectionPage>`
 
@@ -300,6 +310,8 @@ abstract.collections.info({
 ```
 
 ### Create a collection
+
+![CLI][cli-icon] ![API][api-icon]
 
 `collections.create(ProjectDescriptor, NewCollection): Promise<Collection>`
 
@@ -317,6 +329,8 @@ abstract.collections.create({
 
 ### Update a collection
 
+![CLI][cli-icon] ![API][api-icon]
+
 `collections.update(CollectionDescriptor, UpdatedCollection): Promise<Collection>`
 
 Update an existing collection
@@ -332,8 +346,6 @@ abstract.collections.update({
 
 
 ## Comments
-
-![API][api-icon]
 
 A comment in Abstract can be left on a branch, commit, or layer. Comments on layers can also include an optional annotation that
 represents a bounding area ontop of the layer, this can be used to leave comments about specific areas.
@@ -363,6 +375,8 @@ represents a bounding area ontop of the layer, this can be used to leave comment
 
 ### List all comments
 
+![API][api-icon]
+
 `comments.list(BranchDescriptor | CommitDescriptor | PageDescriptor | LayerDescriptor): Promise<Comment[]>`
 
 List the comments for a specific project
@@ -386,6 +400,8 @@ abstract.comments.list({
 
 ### Retrieve a comment
 
+![API][api-icon]
+
 `comments.info(CommentDescriptor): Promise<Comment>`
 
 Load the info for a comment
@@ -397,6 +413,8 @@ abstract.comments.info({
 ```
 
 ### Create a comment
+
+![API][api-icon]
 
 `comments.create(BranchDescriptor | CommitDescriptor | LayerDescriptor, Comment): Promise<Comment>`
 
@@ -436,8 +454,6 @@ abstract.comments.create({
 
 
 ## Commits
-
-![CLI][cli-icon] ![API][api-icon]
 
 A commit represents a point in time – contributors can create commits in the desktop app to save their work at different stages. When loading data from the Abstract SDK you will almost always need to provide a commit `SHA`
 to identify which version of the object you would like.
@@ -484,6 +500,8 @@ to identify which version of the object you would like.
 
 ### List all commits
 
+![CLI][cli-icon] ![API][api-icon]
+
 `commits.list(BranchDescriptor | LayerDescriptor): Promise<Commit[]>`
 
 List the commits for a specific branch
@@ -510,6 +528,8 @@ abstract.commits.list({
 
 ### Retrieve a commit
 
+![CLI][cli-icon] ![API][api-icon]
+
 `commits.info (FileDescriptor | LayerDescriptor | CommitDescriptor): Promise<Commit>`
 
 Load the commit info for a specific commit SHA on a branch
@@ -524,8 +544,6 @@ abstract.commits.info({
 
 
 ## Data
-
-![CLI][cli-icon] ![API][api-icon]
 
 ### The LayerDataset object
 
@@ -554,6 +572,8 @@ abstract.commits.info({
 
 ### Retrieve layer data
 
+![CLI][cli-icon] ![API][api-icon]
+
 `data.info(LayerDescriptor): Promise<LayerDataset>`
 
 ```js
@@ -572,8 +592,6 @@ abstract.data.info({
 
 A file represents a standard file – in Abstract a file is always loaded from a specific commit `SHA`, or point in time.
 
-![CLI][cli-icon] ![API][api-icon]
-
 ### The file object
 
 | Property                     | Type      | Description                                                     |
@@ -590,6 +608,8 @@ A file represents a standard file – in Abstract a file is always loaded from a
 
 ### List all files
 
+![CLI][cli-icon] ![API][api-icon]
+
 `files.list(BranchDescriptor): Promise<File[]>`
 
 List the files for a branch at the latest commit
@@ -603,6 +623,8 @@ abstract.files.list({
 ```
 
 ### Retrieve a file
+
+![CLI][cli-icon] ![API][api-icon]
 
 `files.info(FileDescriptor): Promise<File>`
 
@@ -618,6 +640,8 @@ abstract.files.info({
 ```
 
 ### Retrieve an Sketch file
+
+![CLI][cli-icon]
 
 `files.raw(FileDescriptor, { filename?: string, disableWrite?: boolean }): Promise<ArrayBuffer>`
 
@@ -646,8 +670,6 @@ abstract.files.info({
 
 ## Layers
 
-![CLI][cli-icon] ![API][api-icon]
-
 A layer is a container for designs. In Sketch a layer usually represents an artboard however it can also be a non-contained layer floating on the page.
 
 ### The layer object
@@ -672,6 +694,7 @@ A layer is a container for designs. In Sketch a layer usually represents an artb
 
 ### List all layers
 
+![CLI][cli-icon] ![API][api-icon]
 
 `layers.list(FileDescriptor | PageDescriptor, { limit?: number, offset?: number }): Promise<Layer[]>`
 
@@ -703,6 +726,8 @@ abstract.layers.list({
 
 ### Retrieve a layer
 
+![CLI][cli-icon] ![API][api-icon]
+
 `layers.info(LayerDescriptor): Promise<Layer>`
 
 Load the info for a layer in a file at the latest commit on a branch
@@ -723,8 +748,6 @@ abstract.layers.info({
 
 A membership contains information about a user's role within an organization or a project. A membership is created when a user joins an organization or is given access to a project.
 
-![API][api-icon]
-
 ### The membership object
 
 | Property          | Type     | Description                                                  |
@@ -738,6 +761,8 @@ A membership contains information about a user's role within an organization or 
 
 ### List all memberships
 
+![API][api-icon]
+
 `memberships.list(OrganizationDescriptor | ProjectDescriptor): Promise<Membership[]>`
 
 List the members of an organization
@@ -749,6 +774,8 @@ abstract.memberships.list({
 ```
 
 ### Retrieve a membership
+
+![API][api-icon]
 
 `memberships.info(OrganizationMembershipDescriptor | ProjectMembershipDescriptor): Promise<Membership>`
 
@@ -763,8 +790,6 @@ abstract.memberships.info({
 
 
 ## Notifications
-
-![API][api-icon]
 
 A notification is a user-facing message triggered by an underlying activity. Notifications are both viewable and dismissable in the desktop application.
 
@@ -788,6 +813,8 @@ A notification is a user-facing message triggered by an underlying activity. Not
 
 ### List notifications
 
+![API][api-icon]
+
 `notifications.list(OrganizationDescriptor, { limit?: number, offset?: number }): Promise<Notification[]>`
 
 List the first two notifications for a given organization
@@ -799,6 +826,8 @@ abstract.notifications.list({
 ```
 
 ### Retrieve a notification
+
+![API][api-icon]
 
 `notifications.info(NotificationDescriptor): Promise<Notification>`
 
@@ -812,8 +841,6 @@ abstract.notifications.info({
 
 
 ## Organizations
-
-![API][api-icon]
 
 Organizations contain users and projects.
 
@@ -836,6 +863,8 @@ Organizations contain users and projects.
 
 ### List all organizations
 
+![API][api-icon]
+
 `organizations.list(): Promise<Organization[]>`
 
 Load the organizations accessible by the current access token
@@ -845,6 +874,8 @@ abstract.organizations.list();
 ```
 
 ### Retrieve an organization
+
+![API][api-icon]
 
 `organizations.info(OrganizationDescriptor): Promise<Organization>`
 
@@ -861,8 +892,6 @@ abstract.organizations.info({
 
 A page is a container for layers, often a file will have several pages to organize design work.
 
-![CLI][cli-icon] ![API][api-icon]
-
 ### The page object
 
 | Property    | Type     | Description                                                  |
@@ -876,6 +905,8 @@ A page is a container for layers, often a file will have several pages to organi
 | `type`      | `string` | This field has the value "library" for virtual library pages |
 
 ### List all pages
+
+![CLI][cli-icon] ![API][api-icon]
 
 `pages.list(FileDescriptor): Promise<Page[]>`
 
@@ -891,6 +922,8 @@ abstract.pages.list({
 ```
 
 ### Retrieve a page
+
+![CLI][cli-icon] ![API][api-icon]
 
 `pages.info(PageDescriptor): Promise<Page>`
 
@@ -908,8 +941,6 @@ abstract.pages.info({
 
 ## Previews
 
-![API][api-icon]
-
 A preview is an image file that represents the rendered version of a layer. In Abstract all previews are currently
 only available in PNG format.
 
@@ -920,6 +951,8 @@ only available in PNG format.
 | `webUrl` | `string` | A url to where this preview can be loaded in the Abstract web app |
 
 ### Retrieve an image file
+
+![API][api-icon]
 
 `previews.raw(LayerDescriptor, { filename?: string, disableWrite?: boolean }): Promise<ArrayBuffer>`
 
@@ -960,6 +993,8 @@ fs.writeFile(`preview.png`, Buffer.from(processedBuffer), (err) => {
 
 ### Retrieve a preview image url
 
+![API][api-icon]
+
 > Note: The `previews.url` method requires an environment with [URL.createObjectURL](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL). If you are using node, you will need to save the image to a file with [`previews.raw`](#retrieve-an-image-file)
 
 `previews.url(LayerDescriptor): Promise<string>`
@@ -979,6 +1014,8 @@ abstract.previews.url({
 
 ### Retrieve a preview
 
+![API][api-icon]
+
 `previews.info(LayerDescriptor): Promise<Preview>`
 
 Load the info for a layer preview
@@ -996,8 +1033,6 @@ abstract.previews.info({
 
 
 ## Projects
-
-![API][api-icon]
 
 A project is a container for files, it belongs to an organization. Teams use projects to logically separate their files
 for example for a project, a platform (e.g. Web / iOS), or by client.
@@ -1025,6 +1060,8 @@ for example for a project, a platform (e.g. Web / iOS), or by client.
 
 ### List all projects
 
+![API][api-icon]
+
 `projects.list(OrganizationDescriptor?, { filter?: "active" | "archived" }): Promise<Project[]>`
 
 List all projects accessible through the current authentication
@@ -1051,6 +1088,8 @@ abstract.projects.list({
 
 ### Retrieve a project
 
+![API][api-icon]
+
 `projects.info(ProjectDescriptor): Promise<Project>`
 
 Load the info for a project
@@ -1064,8 +1103,6 @@ abstract.projects.info({
 
 
 ## Shares
-
-![API][api-icon]
 
 A share is a shareable url to an object in Abstract. You can use the desktop or web app to create a share url.
 
@@ -1083,6 +1120,8 @@ A share is a shareable url to an object in Abstract. You can use the desktop or 
 > Note: The `descriptor` property can be used as the first argument for many of the SDK methods
 
 ### Load info for a share
+
+![API][api-icon]
 
 `shares.info(ShareDescriptor): Promise<Share>`
 
@@ -1102,6 +1141,8 @@ abstract.shares.info({
 
 ### Using share.descriptor
 
+![API][api-icon]
+
 List all files for branch's share url
 
 ```js
@@ -1113,6 +1154,8 @@ const branchFiles = await abstract.files.list(branchShare.descriptor);
 ```
 
 ### Create a share
+
+![API][api-icon]
 
 `shares.create(OrganizationDescriptor, InputShare): Promise<Share>`
 
@@ -1136,8 +1179,6 @@ abstract.shares.create({
 
 A user contains information specific to an individual account. Users are global to Abstract and are not specific to organizations. A user is created in the application by creating a new account.
 
-![API][api-icon]
-
 ### The user object
 
 | Property          | Type     | Description                                                  |
@@ -1153,6 +1194,8 @@ A user contains information specific to an individual account. Users are global 
 
 ### List all users
 
+![API][api-icon]
+
 `users.list(OrganizationDescriptor | ProjectDescriptor): Promise<User[]>`
 
 List the users in an organization
@@ -1164,6 +1207,8 @@ abstract.users.list({
 ```
 
 ### Retrieve a user
+
+![API][api-icon]
 
 `users.info(UserDescriptor): Promise<User>`
 

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -110,17 +110,30 @@ abstract.assets.info({
 
 ### Retrieve an asset file
 
-`asset.raw(AssetDescriptor): Promise<ArrayBuffer>`
+`asset.raw(AssetDescriptor, { filename?: string, disableWrite?: boolean }): Promise<ArrayBuffer>`
 
-Load given asset file based on its ID. The resulting `ArrayBuffer` can be used with node `fs` APIs. For example, it's possible to write the image to disk:
+Retrieve a given asset file based on its ID and save it to disk. Files will be saved to the current working directory by default, but a custom `filename` option can be used to customize this location.
+
+```js
+abstract.assets.raw({
+  assetId: "fcd67bab-e5c3-4679-b879-daa5d5746cc2",
+  projectId: "b8bf5540-6e1e-11e6-8526-2d315b6ef48f"
+});
+```
+
+The resulting `ArrayBuffer` can be also be used with node `fs` APIs directly. For example, it's possible to write the image to disk manually after post-processing it:
 
 ```js
 const arrayBuffer = await abstract.assets.raw({
   assetId: "fcd67bab-e5c3-4679-b879-daa5d5746cc2",
   projectId: "b8bf5540-6e1e-11e6-8526-2d315b6ef48f"
+}, {
+  disableWrite: true
 });
 
-fs.writeFile("asset.png", Buffer.from(arrayBuffer), (err) => {
+processedBuffer = postProcess(arrayBuffer);
+
+fs.writeFile("asset.png", Buffer.from(processedBuffer), (err) => {
   if (err) throw err;
   console.log("Asset image written!");
 });
@@ -604,6 +617,21 @@ abstract.files.info({
 });
 ```
 
+### Retrieve an Sketch file
+
+`files.raw(FileDescriptor, { filename?: string, disableWrite?: boolean }): Promise<ArrayBuffer>`
+
+Retrieve a Sketch file from Abstract based on its file ID and save it to disk. Files will be saved to the current working directory by default, but a custom `filename` option can be used to customize this location.
+
+```js
+abstract.files.raw({
+  projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78",
+  branchId: "master",
+  fileId: "51DE7CD1-ECDC-473C-B30E-62AE913743B7"
+  sha: "latest"
+});
+```
+
 You can also load the file info at any commit on the branch…
 
 ```js
@@ -893,9 +921,9 @@ only available in PNG format.
 
 ### Retrieve an image file
 
-`previews.raw(LayerDescriptor): Promise<ArrayBuffer>`
+`previews.raw(LayerDescriptor, { filename?: string, disableWrite?: boolean }): Promise<ArrayBuffer>`
 
-Load the preview image for a layer at a commit. The resulting `ArrayBuffer` can be used with node `fs` API's – for example you can write the image to disk:
+Retrieve a preview image for a layer at a specific commit and save it to disk. Files will be saved to the current working directory by default, but a custom `filename` option can be used to customize this location.
 
 ```js
 const arrayBuffer = await abstract.previews.raw({
@@ -906,8 +934,25 @@ const arrayBuffer = await abstract.previews.raw({
   layerId: "CA420E64-08D0-4B96-B0F7-75AA316B6A19",
   sha: "c4e5578c590f5334349b6d7f0dfd4d3882361f1a" // or sha: "latest"
 });
+```
 
-fs.writeFile(`preview.png`, Buffer.from(arrayBuffer), (err) => {
+The resulting `ArrayBuffer` can be also be used with node `fs` APIs directly. For example, it's possible to write the file to disk manually after post-processing it:
+
+```js
+const arrayBuffer = await abstract.previews.raw({
+  projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78",
+  branchId: "master",
+  fileId: "51DE7CD1-ECDC-473C-B30E-62AE913743B7",
+  pageId: "7D2D2599-9B3F-49BC-9F86-9D9D532F143A",
+  layerId: "CA420E64-08D0-4B96-B0F7-75AA316B6A19",
+  sha: "c4e5578c590f5334349b6d7f0dfd4d3882361f1a" // or sha: "latest"
+}, {
+  disableWrite: true
+});
+
+processedBuffer = postProcess(arrayBuffer);
+
+fs.writeFile(`preview.png`, Buffer.from(processedBuffer), (err) => {
   if (err) throw err;
   console.log("Preview image written!");
 });

--- a/src/endpoints/Activities.js
+++ b/src/endpoints/Activities.js
@@ -13,7 +13,7 @@ import type {
 import Endpoint from "./Endpoint";
 
 export default class Activities extends Endpoint {
-  info(descriptor: ActivityDescriptor): Promise<Activity> {
+  info(descriptor: ActivityDescriptor) {
     return this.request<Promise<Activity>>({
       api: () => {
         return this.apiRequest(`activities/${descriptor.activityId}`);
@@ -28,7 +28,7 @@ export default class Activities extends Endpoint {
   list(
     descriptor: BranchDescriptor | OrganizationDescriptor | ProjectDescriptor,
     options: ListOptions = {}
-  ): CursorPromise<Activity[]> {
+  ) {
     return this.request<CursorPromise<Activity[]>>({
       api: () => {
         return new Cursor<Activity[]>(

--- a/src/endpoints/Assets.js
+++ b/src/endpoints/Assets.js
@@ -7,6 +7,7 @@ import type {
   CommitDescriptor,
   RawOptions
 } from "../types";
+import { isNodeEnvironment } from "../utils";
 import Endpoint from "./Endpoint";
 
 export default class Assets extends Endpoint {
@@ -55,7 +56,7 @@ export default class Assets extends Endpoint {
           null
         );
 
-        if (!options.disableWrite) {
+        if (isNodeEnvironment() && !options.disableWrite) {
           const filename =
             options.filename || `${asset.layerName}.${asset.fileFormat}`;
           fs.writeFile(filename, Buffer.from(arrayBuffer));

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -4,7 +4,7 @@ import type { Branch, BranchDescriptor, ProjectDescriptor } from "../types";
 import Endpoint from "./Endpoint";
 
 export default class Branches extends Endpoint {
-  info(descriptor: BranchDescriptor): Promise<Branch> {
+  info(descriptor: BranchDescriptor) {
     return this.request<Promise<Branch>>({
       api: () => {
         return this.apiRequest(
@@ -30,7 +30,7 @@ export default class Branches extends Endpoint {
   list(
     descriptor: ProjectDescriptor,
     options: { filter?: "active" | "archived" | "mine" } = {}
-  ): Promise<Branch[]> {
+  ) {
     return this.request<Promise<Branch[]>>({
       api: async () => {
         const query = querystring.stringify({ ...options });

--- a/src/endpoints/Changesets.js
+++ b/src/endpoints/Changesets.js
@@ -3,7 +3,7 @@ import type { Changeset, CommitDescriptor } from "../types";
 import Endpoint from "./Endpoint";
 
 export default class Changesets extends Endpoint {
-  async info(descriptor: CommitDescriptor): Promise<Changeset> {
+  async info(descriptor: CommitDescriptor) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );

--- a/src/endpoints/Collections.js
+++ b/src/endpoints/Collections.js
@@ -13,10 +13,7 @@ import type {
 import Endpoint from "./Endpoint";
 
 export default class Collections extends Endpoint {
-  create(
-    descriptor: ProjectDescriptor,
-    collection: NewCollection
-  ): Promise<Collection> {
+  create(descriptor: ProjectDescriptor, collection: NewCollection) {
     return this.request<Promise<Collection>>({
       api: async () => {
         const response = await this.apiRequest(
@@ -36,7 +33,7 @@ export default class Collections extends Endpoint {
     options: { layersPerCollection?: number | "all" } = {
       layersPerCollection: "all"
     }
-  ): Promise<CollectionResponse> {
+  ) {
     return this.request<Promise<CollectionResponse>>({
       api: async () => {
         const query = querystring.stringify({ ...options });
@@ -70,7 +67,7 @@ export default class Collections extends Endpoint {
   list(
     descriptor: ProjectDescriptor | BranchDescriptor,
     options?: { layersPerCollection?: number | "all" } = {}
-  ): Promise<CollectionsResponse> {
+  ) {
     return this.request<Promise<CollectionsResponse>>({
       api: async () => {
         const { projectId, ...sanitizedDescriptor } = descriptor;
@@ -94,10 +91,7 @@ export default class Collections extends Endpoint {
     });
   }
 
-  update(
-    descriptor: CollectionDescriptor,
-    collection: UpdatedCollection
-  ): Promise<Collection> {
+  update(descriptor: CollectionDescriptor, collection: UpdatedCollection) {
     return this.request<Promise<Collection>>({
       api: async () => {
         const response = await this.apiRequest(

--- a/src/endpoints/Comments.js
+++ b/src/endpoints/Comments.js
@@ -25,7 +25,7 @@ export default class Comments extends Endpoint {
           pageId: string
         |},
     comment: NewComment
-  ): Promise<Comment> {
+  ) {
     if (descriptor.sha) {
       descriptor = await this.client.descriptors.getLatestDescriptor(
         descriptor
@@ -47,7 +47,7 @@ export default class Comments extends Endpoint {
     });
   }
 
-  info(descriptor: CommentDescriptor): Promise<Comment> {
+  info(descriptor: CommentDescriptor) {
     return this.request<Promise<Comment>>({
       api: () => {
         return this.apiRequest(`comments/${descriptor.commentId}`);
@@ -66,7 +66,7 @@ export default class Comments extends Endpoint {
       | LayerDescriptor
       | PageDescriptor,
     options: ListOptions = {}
-  ): CursorPromise<Comment[]> {
+  ) {
     let newDescriptor;
     return this.request<CursorPromise<Comment[]>>({
       api: () => {

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -10,9 +10,7 @@ import { NotFoundError } from "../errors";
 import Endpoint from "./Endpoint";
 
 export default class Commits extends Endpoint {
-  info(
-    descriptor: CommitDescriptor | FileDescriptor | LayerDescriptor
-  ): Promise<Commit> {
+  info(descriptor: CommitDescriptor | FileDescriptor | LayerDescriptor) {
     return this.request<Promise<Commit>>({
       api: async () => {
         const commits = await this.list(descriptor, { limit: 1 });
@@ -40,7 +38,7 @@ export default class Commits extends Endpoint {
   list(
     descriptor: CommitDescriptor | FileDescriptor | LayerDescriptor,
     options: { limit?: number } = {}
-  ): Promise<Commit[]> {
+  ) {
     return this.request<Promise<Commit[]>>({
       api: async () => {
         const query = querystring.stringify({

--- a/src/endpoints/Data.js
+++ b/src/endpoints/Data.js
@@ -3,7 +3,7 @@ import type { LayerDataset, LayerDescriptor } from "../types";
 import Endpoint from "./Endpoint";
 
 export default class Data extends Endpoint {
-  async info(descriptor: LayerDescriptor): Promise<LayerDataset> {
+  async info(descriptor: LayerDescriptor) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );

--- a/src/endpoints/Files.js
+++ b/src/endpoints/Files.js
@@ -6,6 +6,7 @@ import type {
   RawOptions
 } from "../types";
 import { NotFoundError } from "../errors";
+import { isNodeEnvironment } from "../utils";
 import Endpoint from "./Endpoint";
 
 export default class Files extends Endpoint {
@@ -72,7 +73,7 @@ export default class Files extends Endpoint {
     );
     return this.request<Promise<void>>({
       cli: async () => {
-        if (options.disableWrite) {
+        if (!isNodeEnvironment() || options.disableWrite) {
           return;
         }
         this.cliRequest([

--- a/src/endpoints/Files.js
+++ b/src/endpoints/Files.js
@@ -1,5 +1,10 @@
 // @flow
-import type { CommitDescriptor, File, FileDescriptor, RawOptions } from "../types";
+import type {
+  CommitDescriptor,
+  File,
+  FileDescriptor,
+  RawOptions
+} from "../types";
 import { NotFoundError } from "../errors";
 import Endpoint from "./Endpoint";
 
@@ -60,7 +65,6 @@ export default class Files extends Endpoint {
       }
     });
   }
-
 
   async raw(descriptor: FileDescriptor, options: RawOptions = {}) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(

--- a/src/endpoints/Files.js
+++ b/src/endpoints/Files.js
@@ -1,10 +1,10 @@
 // @flow
-import type { CommitDescriptor, File, FileDescriptor } from "../types";
+import type { CommitDescriptor, File, FileDescriptor, RawOptions } from "../types";
 import { NotFoundError } from "../errors";
 import Endpoint from "./Endpoint";
 
 export default class Files extends Endpoint {
-  async info(descriptor: FileDescriptor): Promise<File> {
+  async info(descriptor: FileDescriptor) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );
@@ -36,7 +36,7 @@ export default class Files extends Endpoint {
     });
   }
 
-  async list(descriptor: CommitDescriptor): Promise<File[]> {
+  async list(descriptor: CommitDescriptor) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );
@@ -57,6 +57,29 @@ export default class Files extends Endpoint {
           latestDescriptor.sha
         ]);
         return response.files;
+      }
+    });
+  }
+
+
+  async raw(descriptor: FileDescriptor, options: RawOptions = {}) {
+    const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
+      descriptor
+    );
+    return this.request<Promise<void>>({
+      cli: async () => {
+        if (options.disableWrite) {
+          return;
+        }
+        this.cliRequest([
+          "file",
+          "export",
+          latestDescriptor.fileId,
+          options.filename || process.cwd(),
+          `--project-id=${latestDescriptor.projectId}`,
+          `--branch-id=${latestDescriptor.branchId}`,
+          `--sha=${latestDescriptor.sha}`
+        ]);
       }
     });
   }

--- a/src/endpoints/Layers.js
+++ b/src/endpoints/Layers.js
@@ -10,7 +10,7 @@ import type {
 import Endpoint from "./Endpoint";
 
 export default class Layers extends Endpoint {
-  async info(descriptor: LayerDescriptor): Promise<Layer> {
+  async info(descriptor: LayerDescriptor) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );
@@ -52,7 +52,7 @@ export default class Layers extends Endpoint {
   async list(
     descriptor: FileDescriptor | PageDescriptor,
     options: ListOptions = {}
-  ): Promise<Layer[]> {
+  ) {
     descriptor = await this.client.descriptors.getLatestDescriptor(descriptor);
     return this.request<Promise<Layer[]>>({
       api: async () => {

--- a/src/endpoints/Memberships.js
+++ b/src/endpoints/Memberships.js
@@ -11,7 +11,7 @@ import Endpoint from "./Endpoint";
 export default class Users extends Endpoint {
   info(
     descriptor: OrganizationMembershipDescriptor | ProjectMembershipDescriptor
-  ): Promise<Membership> {
+  ) {
     return this.request<Promise<Membership>>({
       api: async () => {
         let url = "";
@@ -34,9 +34,7 @@ export default class Users extends Endpoint {
     });
   }
 
-  list(
-    descriptor: OrganizationDescriptor | ProjectDescriptor
-  ): Promise<Membership[]> {
+  list(descriptor: OrganizationDescriptor | ProjectDescriptor) {
     return this.request<Promise<Membership[]>>({
       api: async () => {
         let url = "";

--- a/src/endpoints/Notifications.js
+++ b/src/endpoints/Notifications.js
@@ -11,7 +11,7 @@ import type {
 import Endpoint from "./Endpoint";
 
 export default class Notifications extends Endpoint {
-  info(descriptor: NotificationDescriptor): Promise<Notification> {
+  info(descriptor: NotificationDescriptor) {
     return this.request<Promise<Notification>>({
       api: () => {
         return this.apiRequest(`notifications/${descriptor.notificationId}`);
@@ -23,10 +23,7 @@ export default class Notifications extends Endpoint {
     });
   }
 
-  list(
-    descriptor: OrganizationDescriptor,
-    options: ListOptions = {}
-  ): CursorPromise<Notification[]> {
+  list(descriptor: OrganizationDescriptor, options: ListOptions = {}) {
     return this.request<CursorPromise<Notification[]>>({
       api: () => {
         return new Cursor<Notification[]>(

--- a/src/endpoints/Organizations.js
+++ b/src/endpoints/Organizations.js
@@ -3,7 +3,7 @@ import type { OrganizationDescriptor, Organization } from "../types";
 import Endpoint from "./Endpoint";
 
 export default class Organizations extends Endpoint {
-  info(descriptor: OrganizationDescriptor): Promise<Organization> {
+  info(descriptor: OrganizationDescriptor) {
     return this.request<Promise<Organization>>({
       api: async () => {
         const response = await this.apiRequest(
@@ -18,7 +18,7 @@ export default class Organizations extends Endpoint {
     });
   }
 
-  list(): Promise<Organization[]> {
+  list() {
     return this.request<Promise<Organization[]>>({
       api: async () => {
         const response = await this.apiRequest("organizations");

--- a/src/endpoints/Pages.js
+++ b/src/endpoints/Pages.js
@@ -4,7 +4,7 @@ import { NotFoundError } from "../errors";
 import Endpoint from "./Endpoint";
 
 export default class Pages extends Endpoint {
-  info(descriptor: PageDescriptor): Promise<Page> {
+  info(descriptor: PageDescriptor) {
     return this.request<Promise<Page>>({
       api: async () => {
         const { pageId, ...fileDescriptor } = descriptor;
@@ -22,7 +22,7 @@ export default class Pages extends Endpoint {
     });
   }
 
-  list(descriptor: FileDescriptor): Promise<Page[]> {
+  list(descriptor: FileDescriptor) {
     return this.request<Promise<Page[]>>({
       api: async () => {
         const response = await this.apiRequest(

--- a/src/endpoints/Previews.js
+++ b/src/endpoints/Previews.js
@@ -3,6 +3,7 @@
 import { promises as fs } from "fs";
 import { FileAPIError } from "../errors";
 import type { LayerDescriptor, PreviewMeta, RawOptions } from "../types";
+import { isNodeEnvironment } from "../utils";
 import Endpoint from "./Endpoint";
 
 export default class Previews extends Endpoint {
@@ -43,7 +44,7 @@ export default class Previews extends Endpoint {
           this.previewsUrl
         );
 
-        if (!options.disableWrite) {
+        if (isNodeEnvironment() && !options.disableWrite) {
           const filename =
             options.filename || `${latestDescriptor.layerId}.png`;
           fs.writeFile(filename, Buffer.from(arrayBuffer));

--- a/src/endpoints/Previews.js
+++ b/src/endpoints/Previews.js
@@ -65,7 +65,7 @@ export default class Previews extends Endpoint {
       throw new FileAPIError();
     }
 
-    const buffer = await this.raw(descriptor, { buffer: true });
+    const buffer = await this.raw(descriptor);
 
     return URL.createObjectURL(
       new Blob([new DataView(buffer)], { type: "image/png" })

--- a/src/endpoints/Previews.js
+++ b/src/endpoints/Previews.js
@@ -1,11 +1,12 @@
 /* @flow */
 /* global Blob */
+import { promises as fs } from "fs";
 import { FileAPIError } from "../errors";
-import type { LayerDescriptor, PreviewMeta } from "../types";
+import type { LayerDescriptor, PreviewMeta, RawOptions } from "../types";
 import Endpoint from "./Endpoint";
 
 export default class Previews extends Endpoint {
-  async info(descriptor: LayerDescriptor): Promise<PreviewMeta> {
+  async info(descriptor: LayerDescriptor) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );
@@ -20,13 +21,13 @@ export default class Previews extends Endpoint {
     });
   }
 
-  async raw(descriptor: LayerDescriptor): Promise<ArrayBuffer> {
+  async raw(descriptor: LayerDescriptor, options: RawOptions = {}) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );
     return this.request<Promise<ArrayBuffer>>({
-      api: () => {
-        return this.apiRawRequest(
+      api: async () => {
+        const arrayBuffer = await this.apiRawRequest(
           `projects/${latestDescriptor.projectId}/commits/${
             latestDescriptor.sha
           }/files/${latestDescriptor.fileId}/layers/${
@@ -41,6 +42,14 @@ export default class Previews extends Endpoint {
           },
           this.previewsUrl
         );
+
+        if (!options.disableWrite) {
+          const filename =
+            options.filename || `${latestDescriptor.layerId}.png`;
+          fs.writeFile(filename, Buffer.from(arrayBuffer));
+        }
+
+        return arrayBuffer;
       },
 
       cache: {
@@ -50,12 +59,12 @@ export default class Previews extends Endpoint {
     });
   }
 
-  async url(descriptor: LayerDescriptor): Promise<string> {
+  async url(descriptor: LayerDescriptor) {
     if (typeof Blob === "undefined") {
       throw new FileAPIError();
     }
 
-    const buffer = await this.raw(descriptor);
+    const buffer = await this.raw(descriptor, { buffer: true });
 
     return URL.createObjectURL(
       new Blob([new DataView(buffer)], { type: "image/png" })

--- a/src/endpoints/Projects.js
+++ b/src/endpoints/Projects.js
@@ -8,7 +8,7 @@ import type {
 import Endpoint from "./Endpoint";
 
 export default class Projects extends Endpoint {
-  info(descriptor: ProjectDescriptor): Promise<Project> {
+  info(descriptor: ProjectDescriptor) {
     return this.request<Promise<Project>>({
       api: async () => {
         const response = await this.apiRequest(
@@ -26,7 +26,7 @@ export default class Projects extends Endpoint {
   list(
     descriptor: OrganizationDescriptor,
     options: { filter?: "active" | "archived" } = {}
-  ): Promise<Project[]> {
+  ) {
     return this.request<Promise<Project[]>>({
       api: async () => {
         const query = querystring.stringify({ ...descriptor, ...options });

--- a/src/endpoints/Shares.js
+++ b/src/endpoints/Shares.js
@@ -13,10 +13,7 @@ const headers = {
 };
 
 export default class Activities extends Endpoint {
-  create<T: Share>(
-    descriptor: OrganizationDescriptor,
-    shareInput: ShareInput
-  ): Promise<T> {
+  create<T: Share>(descriptor: OrganizationDescriptor, shareInput: ShareInput) {
     return this.request<Promise<T>>({
       api: async () => {
         return this.apiRequest("share_links", {
@@ -32,7 +29,7 @@ export default class Activities extends Endpoint {
     });
   }
 
-  info<T: Share>(descriptor: ShareDescriptor): Promise<T> {
+  info<T: Share>(descriptor: ShareDescriptor) {
     return this.request<Promise<T>>({
       api: () => {
         return this.apiRequest(`share_links/${inferShareId(descriptor)}`, {

--- a/src/endpoints/Users.js
+++ b/src/endpoints/Users.js
@@ -8,7 +8,7 @@ import type {
 import Endpoint from "./Endpoint";
 
 export default class Users extends Endpoint {
-  info(descriptor: UserDescriptor): Promise<User> {
+  info(descriptor: UserDescriptor) {
     return this.request<Promise<User>>({
       api: async () => {
         return this.apiRequest(`users/${descriptor.userId}`);
@@ -20,9 +20,7 @@ export default class Users extends Endpoint {
     });
   }
 
-  list(
-    descriptor: OrganizationDescriptor | ProjectDescriptor
-  ): Promise<User[]> {
+  list(descriptor: OrganizationDescriptor | ProjectDescriptor) {
     return this.request<Promise<User[]>>({
       api: async () => {
         let url = "";

--- a/src/types.js
+++ b/src/types.js
@@ -75,6 +75,11 @@ export type ListOptions = {
   offset?: number
 };
 
+export type RawOptions = {
+  disableWrite?: boolean,
+  filename?: string
+};
+
 export type ReviewStatus = "REQUESTED" | "REJECTED" | "APPROVED";
 
 type ActivityBase = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,3 +72,11 @@ export function inferShareId(shareDescriptor: ShareDescriptor): string {
 
   return shareId;
 }
+
+export function isNodeEnvironment(): boolean {
+  return (
+    typeof process !== "undefined" &&
+    process.versions &&
+    process.versions.node !== undefined
+  );
+}


### PR DESCRIPTION
This pull request does the following:
- Modifies all `raw` methods to save to disk by default (per @tommoor)
- Adds `RawOptions` to allow opting-out of disk saving and specifying a custom filename
- Adds `files.raw` support to the CLI transport
- Cleans up duplicated of return types in each endpoint
- Updates documentation so API and CLI indicators are per-method, not per-endpoint

Resolves https://goabstract.atlassian.net/browse/PLATFORM-248