### PR TITLE
bugfix: add missing LayerDataAsset type

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -531,6 +531,8 @@ abstract.commits.info({
 |---------------|-------------------|-------------------------------------------------|
 | `childIds`    | `string[]`        | Array of UUID's for the layers children, if any |
 | `id`          | `string`          | UUID of the chid layer                          |
+| `libraryId`   | `string`          | UUID of the library file this layer is from     |
+| `libraryName` | `string`          | The name of the library file this layer is from |
 | `parentId`    | `string`          | UUID of the parent layer, if any                |
 | `properties`  | `LayerProperties` | Layer properties (to be documented)             |
 | `symbolId`    | `string`          | UUID of the parent symbol, if any               |

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -514,7 +514,7 @@ abstract.commits.info({
 
 ![CLI][cli-icon] ![API][api-icon]
 
-### The data object
+### The LayerDataset object
 
 | Property    | Type        | Description                                                         |
 |-------------|-------------|---------------------------------------------------------------------|
@@ -531,8 +531,6 @@ abstract.commits.info({
 |---------------|-------------------|-------------------------------------------------|
 | `childIds`    | `string[]`        | Array of UUID's for the layers children, if any |
 | `id`          | `string`          | UUID of the chid layer                          |
-| `libraryId`   | `string`          | UUID of the library file this layer is from     |
-| `libraryName` | `string`          | The name of the library file this layer is from |
 | `parentId`    | `string`          | UUID of the parent layer, if any                |
 | `properties`  | `LayerProperties` | Layer properties (to be documented)             |
 | `symbolId`    | `string`          | UUID of the parent symbol, if any               |
@@ -541,7 +539,7 @@ abstract.commits.info({
 
 ### Retrieve layer data
 
-`data.info(LayerDescriptor): Promise<Data>`
+`data.info(LayerDescriptor): Promise<LayerDataset>`
 
 ```js
 abstract.data.info({

--- a/src/endpoints/Data.js
+++ b/src/endpoints/Data.js
@@ -1,13 +1,13 @@
 // @flow
-import type { LayerData, LayerDescriptor } from "../types";
+import type { LayerDataset, LayerDescriptor } from "../types";
 import Endpoint from "./Endpoint";
 
 export default class Data extends Endpoint {
-  async info(descriptor: LayerDescriptor): Promise<LayerData> {
+  async info(descriptor: LayerDescriptor): Promise<LayerDataset> {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );
-    return this.request<Promise<LayerData>>({
+    return this.request<Promise<LayerDataset>>({
       api: () => {
         return this.apiRequest(
           `projects/${latestDescriptor.projectId}/branches/${

--- a/src/types.js
+++ b/src/types.js
@@ -1080,10 +1080,18 @@ export type LayerOverrideData = {
   [layerId: string]: LayerOverrideData
 };
 
+export type LayerDataAsset = {
+  fileFormat: string,
+  formatName: string,
+  namingScheme: string,
+  scale: string
+};
+
 export type LayerDataProperties = {
   styleName?: string,
   name: string,
   isVisible: boolean,
+  isLocked: boolean,
   width: number,
   height: number,
   x: number,
@@ -1095,6 +1103,7 @@ export type LayerDataProperties = {
   textStyleIndex: LayerTextStyle[],
   colorIndex: LayerColor[],
   blendMode: LayerBlendMode,
+  hasClickThrough?: boolean,
   imageId?: string,
   textContent?: string,
   backgroundColor?: LayerColor,
@@ -1104,7 +1113,8 @@ export type LayerDataProperties = {
   borders?: LayerBorder[],
   shadows?: LayerShadows,
   resizingConstraint?: LayerResizingConstraint,
-  overrides?: LayerOverrideData
+  overrides?: LayerOverrideData,
+  assets?: LayerDataAsset[]
 };
 
 export type PreviewMeta = {

--- a/src/types.js
+++ b/src/types.js
@@ -1123,6 +1123,8 @@ export type PreviewMeta = {
 
 export type LayerData = {
   id: string,
+  libraryName: string,
+  libraryId: string,
   symbolId?: string,
   parentId?: string,
   childIds: string[],


### PR DESCRIPTION
This pull request brings the `LayerData` type up to parity with core's `LayerData` type. I noticed these discrepancies while working on embeds: I attempted to use a `LayerIcon` component that uses internal functions typed to core's `LayerData` with `LayerData` returned from the SDK.