### PR TITLE
bugfix: find single commit by sha

### DIFF
--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -13,8 +13,12 @@ export default class Commits extends Endpoint {
   info(descriptor: CommitDescriptor | FileDescriptor | LayerDescriptor) {
     return this.request<Promise<Commit>>({
       api: async () => {
-        const commits = await this.list(descriptor);
-        const commit = commits.find(commit => commit.sha === descriptor.sha);
+        const infoDescriptor = {
+          ...descriptor,
+          startSHA: descriptor.sha
+        };
+
+        const [commit] = await this.list(infoDescriptor, { limit: 1 });
 
         if (!commit) {
           throw new NotFoundError(`sha=${descriptor.sha}`);

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -13,11 +13,13 @@ export default class Commits extends Endpoint {
   info(descriptor: CommitDescriptor | FileDescriptor | LayerDescriptor) {
     return this.request<Promise<Commit>>({
       api: async () => {
-        const commits = await this.list(descriptor, { limit: 1 });
-        if (!commits[0]) {
-          throw new NotFoundError(`commitId=${descriptor.sha}`);
+        const commits = await this.list(descriptor);
+        const commit = commits.find(commit => commit.sha === descriptor.sha);
+
+        if (!commit) {
+          throw new NotFoundError(`sha=${descriptor.sha}`);
         }
-        return commits[0];
+        return commit;
       },
 
       cli: async () => {

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -13,12 +13,10 @@ export default class Commits extends Endpoint {
   info(descriptor: CommitDescriptor | FileDescriptor | LayerDescriptor) {
     return this.request<Promise<Commit>>({
       api: async () => {
-        const infoDescriptor = {
-          ...descriptor,
-          startSHA: descriptor.sha
-        };
-
-        const [commit] = await this.list(infoDescriptor, { limit: 1 });
+        const [commit] = await this.list(descriptor, {
+          limit: 1,
+          startSha: descriptor.sha
+        });
 
         if (!commit) {
           throw new NotFoundError(`sha=${descriptor.sha}`);

--- a/src/endpoints/Commits.test.js
+++ b/src/endpoints/Commits.test.js
@@ -3,9 +3,12 @@ import { mockAPI, mockCLI, API_CLIENT, CLI_CLIENT } from "../testing";
 
 describe("#info", () => {
   test("api", async () => {
-    mockAPI("/projects/project-id/branches/branch-id/commits?", {
-      commits: [{ sha: "sha" }]
-    });
+    mockAPI(
+      "/projects/project-id/branches/branch-id/commits?limit=1&startSha=sha",
+      {
+        commits: [{ sha: "sha" }]
+      }
+    );
     const response = await API_CLIENT.commits.info({
       projectId: "project-id",
       branchId: "branch-id",

--- a/src/endpoints/Commits.test.js
+++ b/src/endpoints/Commits.test.js
@@ -3,20 +3,16 @@ import { mockAPI, mockCLI, API_CLIENT, CLI_CLIENT } from "../testing";
 
 describe("#info", () => {
   test("api", async () => {
-    mockAPI(
-      "/projects/project-id/branches/branch-id/commits?fileId=file-id&limit=1",
-      {
-        commits: [{ id: "commit-id" }]
-      }
-    );
+    mockAPI("/projects/project-id/branches/branch-id/commits?", {
+      commits: [{ sha: "sha" }]
+    });
     const response = await API_CLIENT.commits.info({
       projectId: "project-id",
       branchId: "branch-id",
-      fileId: "file-id",
       sha: "sha"
     });
 
-    expect(response).toEqual({ id: "commit-id" });
+    expect(response).toEqual({ sha: "sha" });
   });
 
   test("cli", async () => {


### PR DESCRIPTION
This pull request updates the `commits.info` endpoint to search for and return individual commits by `sha` instead of arbitrarily using the first commit that's returned from `commits.list`.

Fixes https://github.com/goabstract/abstract-sdk/issues/133