### PR TITLE
feature: use API show action for commits

### DIFF
--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -6,22 +6,17 @@ import type {
   FileDescriptor,
   LayerDescriptor
 } from "../types";
-import { NotFoundError } from "../errors";
 import Endpoint from "./Endpoint";
 
 export default class Commits extends Endpoint {
   info(descriptor: CommitDescriptor | FileDescriptor | LayerDescriptor) {
     return this.request<Promise<Commit>>({
-      api: async () => {
-        const [commit] = await this.list(descriptor, {
-          limit: 1,
-          startSha: descriptor.sha
-        });
-
-        if (!commit) {
-          throw new NotFoundError(`sha=${descriptor.sha}`);
-        }
-        return commit;
+      api: () => {
+        return this.apiRequest(
+          `projects/${descriptor.projectId}/branches/${
+            descriptor.branchId
+          }/commits/${descriptor.sha}`
+        );
       },
 
       cli: async () => {

--- a/src/endpoints/Commits.test.js
+++ b/src/endpoints/Commits.test.js
@@ -3,12 +3,9 @@ import { mockAPI, mockCLI, API_CLIENT, CLI_CLIENT } from "../testing";
 
 describe("#info", () => {
   test("api", async () => {
-    mockAPI(
-      "/projects/project-id/branches/branch-id/commits?limit=1&startSha=sha",
-      {
-        commits: [{ sha: "sha" }]
-      }
-    );
+    mockAPI("/projects/project-id/branches/branch-id/commits/sha", {
+      sha: "sha"
+    });
     const response = await API_CLIENT.commits.info({
       projectId: "project-id",
       branchId: "branch-id",


### PR DESCRIPTION
This pull request updates `Commits#info` to use the [newly-supported API endpoint](https://github.com/goabstract/projects/pull/2345) for commit retrieval instead of relying on `Commits#list`.

Resolves https://goabstract.atlassian.net/browse/PLATFORM-358