### PR TITLE
feature: add pages endpoint to CLI transport

### DIFF
--- a/docs/embed.md
+++ b/docs/embed.md
@@ -3,9 +3,9 @@ id: embed
 title: Embeds
 ---
 
-Embeds can be used to display interactive, up-to-date previews for layers and collections in any environment that supports HTML. To use an embed, create an `<iframe>` with special URL derived from public share URLs.
+Embeds can be used to display interactive, up-to-date previews for layers and collections in any environment that supports HTML. To use an embed, create an `<iframe>` with a special URL derived from public share URLs.
 
-> Note: Only links for layers that are publicly shared can be embedded.
+> Note: Only links for layers or collections that are publicly shared can be embedded.
 
 ## Creating an embed
 

--- a/docs/embed.md
+++ b/docs/embed.md
@@ -1,11 +1,13 @@
 ---
 id: embed
-title: Embed
+title: Embeds
 ---
 
-> Note: Currently only links for layers that are publicly shared can be embedded
+Embeds can be used to display interactive, up-to-date previews for layers and collections in any environment that supports HTML. To use an embed, create an `<iframe>` with special URL derived from public share URLs.
 
-Embed can be used to display the latest preview for an Abstract layer in your document or application.
+> Note: Only links for layers that are publicly shared can be embedded.
+
+## Creating an embed
 
 Given a public share url:
 
@@ -26,8 +28,4 @@ An embed can be created by using the following URL as the `src` of an `<iframe>`
 ></iframe>
 ```
 
-<iframe src="https://app.goabstract.com/embed/c1182fa5-41d4-4f51-a0e2-5506264b65bd" width="640" height="360" frameborder="0" ></iframe>
-
-<hr />
-
-We will be exploring more themes and options like collections in the near future.
+<iframe src="https://app.goabstract.com/embed/c1182fa5-41d4-4f51-a0e2-5506264b65bd" width="640" height="360" frameborder="0"></iframe>

--- a/src/endpoints/Pages.js
+++ b/src/endpoints/Pages.js
@@ -13,7 +13,7 @@ export default class Pages extends Endpoint {
       api: async () => {
         const { pageId, ...fileDescriptor } = latestDescriptor;
         const pages = await this.list(fileDescriptor);
-        const page = pages.find(page => page.id === latestDescriptor.pageId);
+        const page = pages.find(page => page.id === pageId);
         if (!page) {
           throw new NotFoundError(`pageId=${latestDescriptor.pageId}`);
         }

--- a/src/endpoints/Pages.js
+++ b/src/endpoints/Pages.js
@@ -25,7 +25,7 @@ export default class Pages extends Endpoint {
         const pages = await this.list(fileDescriptor);
         const page = pages.find(page => page.id === latestDescriptor.pageId);
         if (!page) {
-          throw new NotFoundError(`pageId=${latestDescriptor.pageId}`);
+          throw new NotFoundError(`pageId=${pageId}`);
         }
         return page;
       },

--- a/src/endpoints/Pages.js
+++ b/src/endpoints/Pages.js
@@ -15,7 +15,7 @@ export default class Pages extends Endpoint {
         const pages = await this.list(fileDescriptor);
         const page = pages.find(page => page.id === pageId);
         if (!page) {
-          throw new NotFoundError(`pageId=${latestDescriptor.pageId}`);
+          throw new NotFoundError(`pageId=${pageId}`);
         }
         return page;
       },

--- a/src/endpoints/Pages.js
+++ b/src/endpoints/Pages.js
@@ -23,7 +23,7 @@ export default class Pages extends Endpoint {
       cli: async () => {
         const { pageId, ...fileDescriptor } = latestDescriptor;
         const pages = await this.list(fileDescriptor);
-        const page = pages.find(page => page.id === latestDescriptor.pageId);
+        const page = pages.find(page => page.id === pageId);
         if (!page) {
           throw new NotFoundError(`pageId=${pageId}`);
         }

--- a/src/endpoints/Pages.test.js
+++ b/src/endpoints/Pages.test.js
@@ -1,5 +1,5 @@
 // @flow
-import { mockAPI, API_CLIENT } from "../testing";
+import { mockAPI, mockCLI, API_CLIENT, CLI_CLIENT } from "../testing";
 
 describe("#info", () => {
   test("api", async () => {
@@ -7,6 +7,21 @@ describe("#info", () => {
       pages: [{ id: "page-id" }]
     });
     const response = await API_CLIENT.pages.info({
+      branchId: "branch-id",
+      fileId: "file-id",
+      pageId: "page-id",
+      projectId: "project-id",
+      sha: "sha"
+    });
+
+    expect(response).toEqual({ id: "page-id" });
+  });
+
+  test("cli", async () => {
+    mockCLI(["files", "project-id", "sha"], {
+      pages: [{ id: "page-id" }]
+    });
+    const response = await CLI_CLIENT.pages.info({
       branchId: "branch-id",
       fileId: "file-id",
       pageId: "page-id",
@@ -24,6 +39,20 @@ describe("#list", () => {
       pages: [{ id: "page-id" }]
     });
     const response = await API_CLIENT.pages.list({
+      branchId: "branch-id",
+      fileId: "file-id",
+      projectId: "project-id",
+      sha: "sha"
+    });
+
+    expect(response).toEqual([{ id: "page-id" }]);
+  });
+
+  test("cli", async () => {
+    mockCLI(["files", "project-id", "sha"], {
+      pages: [{ id: "page-id" }]
+    });
+    const response = await CLI_CLIENT.pages.list({
       branchId: "branch-id",
       fileId: "file-id",
       projectId: "project-id",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -11,7 +11,8 @@
       "transports",
       "pagination",
       "continuous-integration",
-      "latest"
+      "latest",
+      "embed"
     ],
     "API Reference": [
       "abstract-api",


### PR DESCRIPTION
This pull request updates the CLI transport by adding support for `Pages#list` and `Pages#info`. It also updates embed documentation and adds this to the sidebar now that this feature is public.

Resolves https://goabstract.atlassian.net/browse/PLATFORM-376
Resolves #134 