### PR TITLE
feat: Allow async endpoint options

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-mocha": "^5.2.1",
     "eslint-plugin-prettier": "^2.6.2",
     "eslint-plugin-react": "^7.11.1",
-    "flow-bin": "^0.80.0",
+    "flow-bin": "^0.101.0",
     "flow-copy-source": "^2.0.3",
     "jest": "^24.1.0",
     "nock": "^10.0.6",

--- a/src/Client.js
+++ b/src/Client.js
@@ -54,6 +54,7 @@ export default class Client {
       previewsUrl: "https://previews.goabstract.com",
       transportMode: "api",
       webUrl: "https://app.goabstract.com",
+      // $FlowFixMe https://github.com/facebook/flow/pull/7298
       ...options
     };
 

--- a/src/endpoints/Previews.js
+++ b/src/endpoints/Previews.js
@@ -13,7 +13,11 @@ export default class Previews extends Endpoint {
     );
     return this.request<Promise<PreviewMeta>>({
       api: async () => ({
-        webUrl: `${this.webUrl}/projects/${latestDescriptor.projectId}/commits/${latestDescriptor.sha}/files/${latestDescriptor.fileId}/layers/${latestDescriptor.layerId}`
+        webUrl: `${await this.webUrl}/projects/${
+          latestDescriptor.projectId
+        }/commits/${latestDescriptor.sha}/files/${
+          latestDescriptor.fileId
+        }/layers/${latestDescriptor.layerId}`
       })
     });
   }
@@ -33,7 +37,7 @@ export default class Previews extends Endpoint {
               "Abstract-Api-Version": undefined
             }
           },
-          this.previewsUrl
+          await this.previewsUrl
         );
 
         /* istanbul ignore if */

--- a/src/testing.js
+++ b/src/testing.js
@@ -58,12 +58,15 @@ export function mockCLI(
   response?: Object | Array<Object>,
   error?: Object
 ) {
-  child_process.spawn.mockClear();
-  child_process.spawn.mockReturnValueOnce({
+  (child_process.spawn: any).mockClear();
+  (child_process.spawn: any).mockReturnValueOnce({
     stdout: buildTextStream(JSON.stringify(response)),
     stderr: buildTextStream(JSON.stringify(error)),
     on: (name, cb) => {
-      const callArgs = child_process.spawn.mock.calls[0][1].slice(-args.length);
+      const callArgs = (child_process.spawn: any).mock.calls[0][1].slice(
+        -args.length
+      );
+
       expect(callArgs).toEqual(args);
       setTimeout(() => {
         name === "error" && error && cb(1);

--- a/src/types.js
+++ b/src/types.js
@@ -1464,10 +1464,10 @@ export type AccessTokenOption =
 
 export type CommandOptions = {
   accessToken: AccessTokenOption,
-  apiUrl: string,
-  cliPath: string,
+  apiUrl: string | Promise<string>,
+  cliPath: string | Promise<string>,
   maxCacheSize: number,
-  previewsUrl: string,
+  previewsUrl: string | Promise<string>,
   transportMode: "auto" | "api" | "cli",
-  webUrl: string
+  webUrl: string | Promise<string>
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,16 +1718,18 @@ core-js-compat@^3.1.1:
 core-js-pure@3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.3.tgz#4c90752d5b9471f641514f3728f51c1e0783d0b5"
-  integrity sha1-jdi/8loueHJhvvShiFGZIaRPk6w=
+  integrity sha512-k3JWTrcQBKqjkjI0bkfXS0lbpWPxYuHWfMMjC1VDmzU4Q58IwSbuXSo99YO/hUHlw/EB4AlfA2PVxOGkrIq6dA==
   prebuiltVariants:
-    core-js-pure-v3.1.3-darwin-x64-64 "8dd8bff25a2e787261bef4a188519921a44f93ac"
+    core-js-pure-v3.1.3-darwin-x64-64 "96619bd9fc4b05d1f34d0e7b7bcec8c9d379ac2a"
+    core-js-pure-v3.1.3-darwin-x64-72 "87b69ff9eb406daca7992f6a55310af11b99ea85"
 
 core-js@^2.6.5:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
-  integrity sha1-lErzl1fsYnRM65caN2aGWsE+b9c=
+  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
   prebuiltVariants:
-    core-js-v2.6.9-darwin-x64-64 "944af39757ec62744ceb971a3766865ac13e6fd7"
+    core-js-v2.6.9-darwin-x64-64 "754529e0bce2ca56160cf585649485de4ad155cf"
+    core-js-v2.6.9-darwin-x64-72 "4e1aa072ee107ba0fdc24d1f8b6fd5bdf163eee5"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2524,12 +2526,13 @@ fs.realpath@^1.0.0:
 fsevents@^1.2.7:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.9.tgz#3f5ed66583ccd6f400b5a00db6f7e861363e388f"
-  integrity sha1-PMc37pUvn5CJ+kY3JE2RXKEAn9I=
+  integrity sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==
   dependencies:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
   prebuiltVariants:
-    fsevents-v1.2.9-darwin-x64-64 "3cc737ee952f9f9089fa4637244d915ca1009fd2"
+    fsevents-v1.2.9-darwin-x64-64 db7989b1fa6e84f2c0370738155823d06cda69ae
+    fsevents-v1.2.9-darwin-x64-72 "826769999d35c9a3f56c64375cfadce44ff42b37"
 
 fsevents@^2.0.6:
   version "2.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,16 +1718,16 @@ core-js-compat@^3.1.1:
 core-js-pure@3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.3.tgz#4c90752d5b9471f641514f3728f51c1e0783d0b5"
-  integrity sha512-k3JWTrcQBKqjkjI0bkfXS0lbpWPxYuHWfMMjC1VDmzU4Q58IwSbuXSo99YO/hUHlw/EB4AlfA2PVxOGkrIq6dA==
+  integrity sha1-jdi/8loueHJhvvShiFGZIaRPk6w=
   prebuiltVariants:
-    core-js-pure-v3.1.3-darwin-x64-64 "96619bd9fc4b05d1f34d0e7b7bcec8c9d379ac2a"
+    core-js-pure-v3.1.3-darwin-x64-64 "8dd8bff25a2e787261bef4a188519921a44f93ac"
 
 core-js@^2.6.5:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
-  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
+  integrity sha1-lErzl1fsYnRM65caN2aGWsE+b9c=
   prebuiltVariants:
-    core-js-v2.6.9-darwin-x64-64 "754529e0bce2ca56160cf585649485de4ad155cf"
+    core-js-v2.6.9-darwin-x64-64 "944af39757ec62744ceb971a3766865ac13e6fd7"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2424,10 +2424,10 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
-flow-bin@^0.80.0:
-  version "0.80.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.80.0.tgz#04cc1ee626a6f50786f78170c92ebe1745235403"
-  integrity sha512-0wRnqvXErQRPrx6GBLB5swgndfWkotd9MgfePgT7Z+VsE046c8Apzl7KKTCypB/pzn0pZF2g5Jurxxb2umET8g==
+flow-bin@^0.101.0:
+  version "0.101.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.101.1.tgz#6175eb4a2e510949decf4750cb573f83ddf303f2"
+  integrity sha512-+HVuoMgWNK8vIM662Rt6OzlJNTnC+BWChdeYjkPpl70TKiRMt//j6/5x6PH8HVZ/vytOfPZw2b/JrlBHdlGCkQ==
 
 flow-copy-source@^2.0.3:
   version "2.0.6"
@@ -2524,12 +2524,12 @@ fs.realpath@^1.0.0:
 fsevents@^1.2.7:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.9.tgz#3f5ed66583ccd6f400b5a00db6f7e861363e388f"
-  integrity sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==
+  integrity sha1-PMc37pUvn5CJ+kY3JE2RXKEAn9I=
   dependencies:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
   prebuiltVariants:
-    fsevents-v1.2.9-darwin-x64-64 db7989b1fa6e84f2c0370738155823d06cda69ae
+    fsevents-v1.2.9-darwin-x64-64 "3cc737ee952f9f9089fa4637244d915ca1009fd2"
 
 fsevents@^2.0.6:
   version "2.0.7"


### PR DESCRIPTION
To support desktop's async config https://github.com/goabstract/ui/pull/1215 we need to allow for `previewsUrl` to be async

I went ahead and updated `previewsUrl` and the remaining configs that may be used asynchronously one day. Was straight forward because everywhere these options are used were already async 👍 

- Change `previewsUrl`, `apiUrl`, 'webUrl', and `cliPath` to `string | Promise<string>`
- Upgrade flow to asssit with suppressing spread bug with unions and to match the  ui version

