### PR TITLE
chore: update cli collection endpoints to use abstract-cli 2.0 response schema

### DIFF
--- a/src/endpoints/Collections.js
+++ b/src/endpoints/Collections.js
@@ -47,13 +47,18 @@ export default class Collections extends Endpoint {
         };
       },
 
-      cli: () => {
-        return this.cliRequest([
+      cli: async () => {
+        const response = await this.cliRequest([
           "collection",
           "load",
           descriptor.projectId,
           descriptor.collectionId
         ]);
+        const { collections, ...meta } = response.data;
+        return {
+          collection: collections[0],
+          ...meta
+        };
       },
 
       cache: {
@@ -79,12 +84,13 @@ export default class Collections extends Endpoint {
         return response.data;
       },
 
-      cli: () => {
-        return this.cliRequest([
+      cli: async () => {
+        const response = await this.cliRequest([
           "collections",
           descriptor.projectId,
           ...(descriptor.branchId ? ["--branch", descriptor.branchId] : [])
         ]);
+        return response.data;
       }
     });
   }

--- a/src/endpoints/Collections.test.js
+++ b/src/endpoints/Collections.test.js
@@ -39,7 +39,9 @@ describe("#info", () => {
 
   test("cli", async () => {
     mockCLI(["collection", "load", "project-id", "collection-id"], {
-      collection: { id: "collection-id" }
+      data: {
+        collections: [{ id: "collection-id" }]
+      }
     });
     const response = await CLI_CLIENT.collections.info({
       projectId: "project-id",
@@ -64,7 +66,7 @@ describe("#list", () => {
 
   test("cli", async () => {
     mockCLI(["collections", "project-id", "--branch", "branch-id"], {
-      collections: [{ id: "collection-id" }]
+      data: { collections: [{ id: "collection-id" }] }
     });
     const response = await CLI_CLIENT.collections.list({
       projectId: "project-id",
@@ -76,7 +78,7 @@ describe("#list", () => {
 
   test("cli - no branch id", async () => {
     mockCLI(["collections", "project-id"], {
-      collections: [{ id: "collection-id" }]
+      data: { collections: [{ id: "collection-id" }] }
     });
 
     const response = await CLI_CLIENT.collections.list({


### PR DESCRIPTION
As of abstract-cli 2.0, the abstract-cli responses for collections match the structure of the API's responses. This PR updates the collection's `list` and `info` functions to use the new structure.