### PR TITLE
docs: Document the `updatedAt` field in the File object

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -605,6 +605,7 @@ A file represents a standard file – in Abstract a file is always loaded from a
 | `projectId`                  | `string`  | UUID of the project this file belongs to                        |
 | `sha`                        | `string`  | SHA that this file was loaded at                                |
 | `type`                       | `string`  | The application that the file was created in                    |
+| `updatedAt`                  | `string`  | The timestamp of the last change to the file                    |
 
 ### List all files
 


### PR DESCRIPTION
I noticed the File object now comes with a (very useful) `updatedAt` field. I'm raising this to document it in the APIs.