### PR TITLE
docs: Fix a typo in the Files API documentation

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -639,7 +639,7 @@ abstract.files.info({
 });
 ```
 
-### Retrieve an Sketch file
+### Retrieve a Sketch file
 
 ![CLI][cli-icon]
 


### PR DESCRIPTION
`Retrieve an Sketch file` → `Retrieve a Sketch file`.

Note that this will break any permalinks to the header.