### PR TITLE
fix: Await the CLI request in files.raw

### DIFF
--- a/src/endpoints/Files.js
+++ b/src/endpoints/Files.js
@@ -75,7 +75,7 @@ export default class Files extends Endpoint {
         if (!isNodeEnvironment() || options.disableWrite) {
           return;
         }
-        this.cliRequest([
+        await this.cliRequest([
           "file",
           "export",
           latestDescriptor.fileId,


### PR DESCRIPTION
Exporting files using the CLI works successfully for me, but I noticed that the client doesn't actually wait until they've finished exporting — it just kicks it off. This is problematic, because there's no real good way for a client application to check if the file has been exported in time, other than waiting (which might be really long if there are a lot of files in the export!).

It seems like this request was always intended to be `await`ed, since the method itself is `async`. Otherwise, could you provide some guidance or workaround for this issue? Does it need to be fixed on the CLI itself?