### PR TITLE
fix: commits.list input descriptor and docs

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -520,9 +520,7 @@ abstract.commits.list({
   projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78",
   branchId: "master",
   fileId: "51DE7CD1-ECDC-473C-B30E-62AE913743B7",
-  pageId: "7D2D2599-9B3F-49BC-9F86-9D9D532F143A",
   layerId: "CA420E64-08D0-4B96-B0F7-75AA316B6A19",
-  sha: "latest"
 });
 ```
 

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -502,7 +502,7 @@ to identify which version of the object you would like.
 
 ![CLI][cli-icon] ![API][api-icon]
 
-`commits.list(BranchDescriptor | LayerDescriptor): Promise<Commit[]>`
+`commits.list(BranchDescriptor, options): Promise<Commit[]>`
 
 List the commits for a specific branch
 
@@ -513,14 +513,18 @@ abstract.commits.list({
 });
 ```
 
-or, get a list of commits for a layer – this query will only return commits where the referenced layer was changed…
+or, filter the list of branch commits to a single layer by providing a file id and layer id. This will only return commits where the referenced layer was changed…
 
 ```js
-abstract.commits.list({
-  projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78",
-  branchId: "master",
-  fileId: "51DE7CD1-ECDC-473C-B30E-62AE913743B7",
-  layerId: "CA420E64-08D0-4B96-B0F7-75AA316B6A19",
+abstract.commits.list(
+  {
+    projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78",
+    branchId: "master",
+  },
+  {
+    fileId: "51DE7CD1-ECDC-473C-B30E-62AE913743B7",
+    layerId: "CA420E64-08D0-4B96-B0F7-75AA316B6A19"
+  }
 });
 ```
 

--- a/src/Client.test.js
+++ b/src/Client.test.js
@@ -58,12 +58,9 @@ describe("cache", () => {
     };
 
     for (let i = 0; i < 2; i++) {
-      mockAPI(
-        "/projects/project-id/branches/branch-id/commits?fileId=file-id&limit=1",
-        {
-          commits: [{ id: "commit-id" }]
-        }
-      );
+      mockAPI("/projects/project-id/branches/branch-id/commits?limit=1", {
+        commits: [{ id: "commit-id" }]
+      });
       mockAPI("/projects/project-id/branches/branch-id/files", { files });
     }
 

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -45,15 +45,16 @@ export default class Commits extends Endpoint {
   ) {
     return this.request<Promise<Commit[]>>({
       api: async () => {
-        const query = querystring.stringify({
+        let query = querystring.stringify({
           fileId: options.fileId,
           layerId: options.layerId,
           startSHA: options.startSHA,
           endSHA: options.endSHA,
           limit: options.limit
         });
+        query = query ? `?${query}` : "";
         const response = await this.apiRequest(
-          `projects/${descriptor.projectId}/branches/${descriptor.branchId}/commits?${query}`
+          `projects/${descriptor.projectId}/branches/${descriptor.branchId}/commits${query}`
         );
         return response.commits;
       },
@@ -65,8 +66,8 @@ export default class Commits extends Endpoint {
           descriptor.branchId,
           ...(options.fileId ? ["--file-id", options.fileId] : []),
           ...(options.layerId ? ["--layer-id", options.layerId] : []),
-          ...(options.startSHA ? ["--file-id", options.startSHA] : []),
-          ...(options.endSHA ? ["--layer-id", options.endSHA] : []),
+          ...(options.startSHA ? ["--start-sha", options.startSHA] : []),
+          ...(options.endSHA ? ["--end-sha", options.endSHA] : []),
           ...(options.limit ? ["--limit", options.limit.toString()] : [])
         ]);
         return response.commits;

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -1,6 +1,7 @@
 // @flow
 import querystring from "query-string";
 import type {
+  BranchDescriptor,
   Commit,
   CommitDescriptor,
   FileDescriptor,
@@ -33,7 +34,7 @@ export default class Commits extends Endpoint {
   }
 
   list(
-    descriptor: CommitDescriptor | FileDescriptor | LayerDescriptor,
+    descriptor: BranchDescriptor | LayerDescriptor,
     options: { limit?: number } = {}
   ) {
     return this.request<Promise<Commit[]>>({

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -34,15 +34,23 @@ export default class Commits extends Endpoint {
   }
 
   list(
-    descriptor: BranchDescriptor | LayerDescriptor,
-    options: { limit?: number } = {}
+    descriptor: BranchDescriptor,
+    options: {
+      fileId?: string,
+      layerId?: string,
+      startSHA?: string,
+      endSHA?: string,
+      limit?: number
+    } = {}
   ) {
     return this.request<Promise<Commit[]>>({
       api: async () => {
         const query = querystring.stringify({
-          ...options,
-          fileId: descriptor.fileId && descriptor.fileId,
-          layerId: descriptor.layerId && descriptor.layerId
+          fileId: options.fileId,
+          layerId: options.layerId,
+          startSHA: options.startSHA,
+          endSHA: options.endSHA,
+          limit: options.limit
         });
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}/branches/${descriptor.branchId}/commits?${query}`
@@ -55,8 +63,10 @@ export default class Commits extends Endpoint {
           "commits",
           descriptor.projectId,
           descriptor.branchId,
-          ...(descriptor.fileId ? ["--file-id", descriptor.fileId] : []),
-          ...(descriptor.layerId ? ["--layer-id", descriptor.layerId] : []),
+          ...(options.fileId ? ["--file-id", options.fileId] : []),
+          ...(options.layerId ? ["--layer-id", options.layerId] : []),
+          ...(options.startSHA ? ["--file-id", options.startSHA] : []),
+          ...(options.endSHA ? ["--layer-id", options.endSHA] : []),
           ...(options.limit ? ["--limit", options.limit.toString()] : [])
         ]);
         return response.commits;

--- a/src/endpoints/Commits.test.js
+++ b/src/endpoints/Commits.test.js
@@ -38,12 +38,13 @@ describe("#list", () => {
     const response = await API_CLIENT.commits.list(
       {
         projectId: "project-id",
-        branchId: "branch-id",
+        branchId: "branch-id"
+      },
+      {
         fileId: "file-id",
         layerId: "layer-id",
-        sha: "sha"
-      },
-      { limit: 10 }
+        limit: 10
+      }
     );
 
     expect(response).toEqual([]);
@@ -57,6 +58,8 @@ describe("#list", () => {
         "branch-id",
         "--file-id",
         "file-id",
+        "--layer-id",
+        "layer-id",
         "--limit",
         "10"
       ],
@@ -65,11 +68,13 @@ describe("#list", () => {
     const response = await CLI_CLIENT.commits.list(
       {
         projectId: "project-id",
-        branchId: "branch-id",
-        fileId: "file-id",
-        sha: "sha"
+        branchId: "branch-id"
       },
-      { limit: 10 }
+      {
+        fileId: "file-id",
+        layerId: "layer-id",
+        limit: 10
+      }
     );
 
     expect(response).toEqual([]);
@@ -81,6 +86,8 @@ describe("#list", () => {
         "commits",
         "project-id",
         "branch-id",
+        "--file-id",
+        "file-id",
         "--layer-id",
         "layer-id",
         "--limit",
@@ -89,13 +96,15 @@ describe("#list", () => {
       { commits: [] }
     );
     const response = await CLI_CLIENT.commits.list(
-      ({
+      {
         projectId: "project-id",
-        branchId: "branch-id",
+        branchId: "branch-id"
+      },
+      {
+        fileId: "file-id",
         layerId: "layer-id",
-        sha: "sha"
-      }: any),
-      { limit: 10 }
+        limit: 10
+      }
     );
 
     expect(response).toEqual([]);

--- a/src/endpoints/Commits.test.js
+++ b/src/endpoints/Commits.test.js
@@ -28,85 +28,89 @@ describe("#info", () => {
 });
 
 describe("#list", () => {
-  test("api", async () => {
-    mockAPI(
-      "/projects/project-id/branches/branch-id/commits?fileId=file-id&layerId=layer-id&limit=10",
-      {
+  describe("api", () => {
+    test("no options", async () => {
+      mockAPI("/projects/project-id/branches/branch-id/commits", {
         commits: []
-      }
-    );
-    const response = await API_CLIENT.commits.list(
-      {
+      });
+      const response = await API_CLIENT.commits.list({
         projectId: "project-id",
         branchId: "branch-id"
-      },
-      {
-        fileId: "file-id",
-        layerId: "layer-id",
-        limit: 10
-      }
-    );
+      });
 
-    expect(response).toEqual([]);
+      expect(response).toEqual([]);
+    });
+
+    test("all options", async () => {
+      mockAPI(
+        "/projects/project-id/branches/branch-id/commits?endSHA=end-sha&fileId=file-id&layerId=layer-id&limit=10&startSHA=start-sha",
+        {
+          commits: []
+        }
+      );
+      const response = await API_CLIENT.commits.list(
+        {
+          projectId: "project-id",
+          branchId: "branch-id"
+        },
+        {
+          fileId: "file-id",
+          layerId: "layer-id",
+          limit: 10,
+          startSHA: "start-sha",
+          endSHA: "end-sha"
+        }
+      );
+
+      expect(response).toEqual([]);
+    });
   });
 
-  test("cli - file id", async () => {
-    mockCLI(
-      [
-        "commits",
-        "project-id",
-        "branch-id",
-        "--file-id",
-        "file-id",
-        "--layer-id",
-        "layer-id",
-        "--limit",
-        "10"
-      ],
-      { commits: [] }
-    );
-    const response = await CLI_CLIENT.commits.list(
-      {
+  describe("cli", () => {
+    test("no options", async () => {
+      mockCLI(["commits", "project-id", "branch-id"], { commits: [] });
+      const response = await CLI_CLIENT.commits.list({
         projectId: "project-id",
         branchId: "branch-id"
-      },
-      {
-        fileId: "file-id",
-        layerId: "layer-id",
-        limit: 10
-      }
-    );
+      });
 
-    expect(response).toEqual([]);
-  });
+      expect(response).toEqual([]);
+    });
 
-  test("cli - layer id", async () => {
-    mockCLI(
-      [
-        "commits",
-        "project-id",
-        "branch-id",
-        "--file-id",
-        "file-id",
-        "--layer-id",
-        "layer-id",
-        "--limit",
-        "10"
-      ],
-      { commits: [] }
-    );
-    const response = await CLI_CLIENT.commits.list(
-      {
-        projectId: "project-id",
-        branchId: "branch-id"
-      },
-      {
-        fileId: "file-id",
-        layerId: "layer-id",
-        limit: 10
-      }
-    );
+    test("all options", async () => {
+      mockCLI(
+        [
+          "commits",
+          "project-id",
+          "branch-id",
+          "--file-id",
+          "file-id",
+          "--layer-id",
+          "layer-id",
+          "--start-sha",
+          "start-sha",
+          "--end-sha",
+          "end-sha",
+          "--limit",
+          "10"
+        ],
+        { commits: [] }
+      );
+      const response = await CLI_CLIENT.commits.list(
+        {
+          projectId: "project-id",
+          branchId: "branch-id"
+        },
+        {
+          fileId: "file-id",
+          layerId: "layer-id",
+          limit: 10,
+          startSHA: "start-sha",
+          endSHA: "end-sha"
+        }
+      );
 
-    expect(response).toEqual([]);
+      expect(response).toEqual([]);
+    });
   });
 });

--- a/src/endpoints/Files.js
+++ b/src/endpoints/Files.js
@@ -16,8 +16,8 @@ export default class Files extends Endpoint {
     );
     return this.request<Promise<File>>({
       api: async () => {
-        const { fileId, ...branchDescriptor } = latestDescriptor;
-        const files = await this.list(branchDescriptor);
+        const { fileId, ...commitDescriptor } = latestDescriptor;
+        const files = await this.list(commitDescriptor);
         const file = files.find(file => file.id === latestDescriptor.fileId);
         if (!file) {
           throw new NotFoundError(`fileId=${latestDescriptor.fileId}`);

--- a/src/errors.test.js
+++ b/src/errors.test.js
@@ -42,12 +42,16 @@ describe("errors", () => {
     });
 
     try {
-      await client.commits.list({
-        projectId: "project-id",
-        branchId: "branch-id",
-        fileId: "file-id",
-        sha: "sha"
-      });
+      await client.commits.list(
+        {
+          projectId: "project-id",
+          branchId: "branch-id"
+        },
+        {
+          fileId: "file-id",
+          layerId: "layer-id"
+        }
+      );
     } catch (error) {
       expect(error).toBeInstanceOf(CLIPathError);
     }


### PR DESCRIPTION
I tried to use `commits.list` inside of abstract and couldn't do it the way it's currently typed, and I found some types that need updating. Will leave comments inline.