### PR TITLE
fix: ignore test files when generating typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "commitlint": "commitlint --edit",
     "lint": "eslint . --ignore-path .gitignore",
     "test": "jest --coverage",
-    "prebuild": "rm -rf lib && flow-copy-source -i *.test.js src lib",
+    "prebuild": "rm -rf lib && flow-copy-source -i *.test.js -i endpoints/*.test.js -i testing.js src lib",
     "build": "babel src -d lib --ignore **/*.test.js",
     "prepublish": "yarn build",
     "release": "standard-version"


### PR DESCRIPTION
This pull request excludes test-related files from `flow-copy-source` used during the `prebuild` task.

References: https://goabstract.atlassian.net/browse/PLATFORM-490