### PR TITLE
fix: disable caching of non-static entities

### DIFF
--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -19,10 +19,6 @@ export default class Branches extends Endpoint {
           descriptor.projectId,
           descriptor.branchId
         ]);
-      },
-
-      cache: {
-        key: `branch:${descriptor.branchId}`
       }
     });
   }

--- a/src/endpoints/Collections.js
+++ b/src/endpoints/Collections.js
@@ -59,10 +59,6 @@ export default class Collections extends Endpoint {
           collection: collections[0],
           ...meta
         };
-      },
-
-      cache: {
-        key: `collection:${descriptor.collectionId}`
       }
     });
   }

--- a/src/endpoints/Comments.js
+++ b/src/endpoints/Comments.js
@@ -51,10 +51,6 @@ export default class Comments extends Endpoint {
     return this.request<Promise<Comment>>({
       api: () => {
         return this.apiRequest(`comments/${descriptor.commentId}`);
-      },
-
-      cache: {
-        key: `comment:${descriptor.commentId}`
       }
     });
   }

--- a/src/endpoints/Organizations.js
+++ b/src/endpoints/Organizations.js
@@ -10,10 +10,6 @@ export default class Organizations extends Endpoint {
           `organizations/${descriptor.organizationId}`
         );
         return response.data;
-      },
-
-      cache: {
-        key: `organization:${descriptor.organizationId}`
       }
     });
   }

--- a/src/endpoints/Pages.js
+++ b/src/endpoints/Pages.js
@@ -28,10 +28,6 @@ export default class Pages extends Endpoint {
           throw new NotFoundError(`pageId=${pageId}`);
         }
         return page;
-      },
-
-      cache: {
-        key: `page:${descriptor.pageId}`
       }
     });
   }

--- a/src/endpoints/Projects.js
+++ b/src/endpoints/Projects.js
@@ -15,10 +15,6 @@ export default class Projects extends Endpoint {
           `projects/${descriptor.projectId}`
         );
         return response.data;
-      },
-
-      cache: {
-        key: `project:${descriptor.projectId}`
       }
     });
   }

--- a/src/endpoints/Users.js
+++ b/src/endpoints/Users.js
@@ -12,10 +12,6 @@ export default class Users extends Endpoint {
     return this.request<Promise<User>>({
       api: async () => {
         return this.apiRequest(`users/${descriptor.userId}`);
-      },
-
-      cache: {
-        key: `user:${descriptor.userId}`
       }
     });
   }


### PR DESCRIPTION
This pull request removes caching from non-static endpoints. This was a total oversight and could result in stale, cached entities being returned instead of the most up-to-date version.

After this change, the entity types below are the only ones that we'll cache (since they are all either static or requested using a static `sha`):

```
Activity
Asset
Changeset
Commit
Data
File
Layer
Membership
Notification
Preview
Share
```

References https://goabstract.atlassian.net/browse/PLATFORM-490