### PR TITLE
Typescript 3.5.3 type errors fixed

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -198,7 +198,7 @@ interface Commits extends Endpoint {
 
   list(
     descriptor: CommitDescriptor | FileDescriptor | LayerDescriptor,
-    options: { limit?: number }
+    options?: { limit?: number }
   ): Promise<Commit[]>;
 }
 

--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -104,7 +104,7 @@ interface Endpoint {
   transportMode: string;
   webUrl: string | Promise<string>;
 
-  constructor(client: Client, options: CommandOptions): any;
+  constructor(client: Client, options: CommandOptions): Endpoint;
   accessToken: () => Promise<AccessToken>;
   cliRequest(args: string[]): Promise<any>;
   request<T>(request: EndpointRequest<T>): T;
@@ -1332,9 +1332,9 @@ type LayerTextStyle = {
 };
 
 type LayerOverrideData = {
-  symbolId?: any,
+  symbolId?: string,
   properties?: any,
-  [layerId: string]: LayerOverrideData
+  [layerId: string]: string | undefined
 };
 
 type LayerDataAsset = {

--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -104,7 +104,7 @@ interface Endpoint {
   transportMode: string;
   webUrl: string | Promise<string>;
 
-  constructor(client: Client, options: CommandOptions);
+  constructor(client: Client, options: CommandOptions): any;
   accessToken: () => Promise<AccessToken>;
   cliRequest(args: string[]): Promise<any>;
   request<T>(request: EndpointRequest<T>): T;
@@ -198,7 +198,7 @@ interface Commits extends Endpoint {
 
   list(
     descriptor: CommitDescriptor | FileDescriptor | LayerDescriptor,
-    options: { limit?: number } = {}
+    options: { limit?: number }
   ): Promise<Commit[]>;
 }
 
@@ -1332,7 +1332,7 @@ type LayerTextStyle = {
 };
 
 type LayerOverrideData = {
-  symbolId?: string,
+  symbolId?: any,
   properties?: any,
   [layerId: string]: LayerOverrideData
 };


### PR DESCRIPTION
Typescript compilation fails due to 3 errors in the type file abstract-sdk.d.ts. Tested on Typescript versions 3.5.2 and 3.5.3.