### PR TITLE
chore: Remove undocumented project.userIds from types

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -642,8 +642,7 @@ type Organization = {
   publicSharingEnabled?: boolean,
   restrictedToDomains: string[],
   trialEndsAt?: string,
-  userId: string,
-  userIds: string[]
+  userId: string
 };
 
 type Project = {
@@ -662,8 +661,7 @@ type Project = {
   pushedAt: string,
   repoCreatedAt: string,
   visibility: "organization" | "project",
-  sizeInBytes: number,
-  userIds: [string]
+  sizeInBytes: number
 };
 
 type BaseShare = {

--- a/src/types.js
+++ b/src/types.js
@@ -363,8 +363,7 @@ export type Organization = {
   publicSharingEnabled?: boolean,
   restrictedToDomains: string[],
   trialEndsAt?: string,
-  userId: string,
-  userIds: string[]
+  userId: string
 };
 
 export type Project = {
@@ -383,8 +382,7 @@ export type Project = {
   pushedAt: string,
   repoCreatedAt: string,
   visibility: "organization" | "project",
-  sizeInBytes: number,
-  userIds: [string]
+  sizeInBytes: number
 };
 
 type BaseShare = {|


### PR DESCRIPTION
This value was never documented and we're going to stop sending it down from the server shortly.