### PR TITLE
chore: upgrade flow to 110

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-mocha": "^5.2.1",
     "eslint-plugin-prettier": "^2.6.2",
     "eslint-plugin-react": "^7.11.1",
-    "flow-bin": "^0.101.0",
+    "flow-bin": "^0.110.1",
     "flow-copy-source": "^2.0.3",
     "jest": "^24.1.0",
     "nock": "^10.0.6",

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -198,7 +198,7 @@ export default class Endpoint {
     return response;
   }
 
-  async _getAPIHeaders(headers?: {}) {
+  async _getAPIHeaders(customHeaders?: { [key: string]: string }) {
     let tokenHeader = {};
     const token = await this.accessToken();
 
@@ -216,18 +216,23 @@ export default class Endpoint {
           : { "Abstract-Share-Id": inferShareId(token) };
     }
 
-    const tokens: { [string]: ?string } = {
+    const baseHeaders = {
       Accept: "application/json",
       "Content-Type": "application/json",
       "User-Agent": `Abstract SDK ${minorVersion}`,
       "X-Amzn-Trace-Id": `Root=1-${new Date().getTime()}-${uuid()}`,
-      "Abstract-Api-Version": "8",
-      ...tokenHeader,
-      ...headers
+      "Abstract-Api-Version": "8"
     };
-    Object.keys(tokens).forEach(key => {
-      tokens[key] === undefined && delete tokens[key];
+
+    const headers = {
+      ...baseHeaders,
+      ...tokenHeader,
+      ...customHeaders
+    };
+
+    Object.keys(headers).forEach(key => {
+      headers[key] === undefined && delete headers[key];
     });
-    return tokens;
+    return headers;
   }
 }

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -216,7 +216,7 @@ export default class Endpoint {
           : { "Abstract-Share-Id": inferShareId(token) };
     }
 
-    const tokens = {
+    const tokens: { [string]: ?string } = {
       Accept: "application/json",
       "Content-Type": "application/json",
       "User-Agent": `Abstract SDK ${minorVersion}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,10 +2976,10 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
-flow-bin@^0.101.0:
-  version "0.101.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.101.1.tgz#6175eb4a2e510949decf4750cb573f83ddf303f2"
-  integrity sha512-+HVuoMgWNK8vIM662Rt6OzlJNTnC+BWChdeYjkPpl70TKiRMt//j6/5x6PH8HVZ/vytOfPZw2b/JrlBHdlGCkQ==
+flow-bin@^0.110.1:
+  version "0.110.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.110.1.tgz#24ac70bf0871a5d6bc181ba99801ded4d5e3b442"
+  integrity sha512-6FhvNKNvPQ523mx7sqNxTQvI/HgAWa/pbIsQuCst53qRqs387EFfYqgm4I3Zae5HLaVFacBwgWKmjKd92vf19w==
 
 flow-copy-source@^2.0.3:
   version "2.0.8"


### PR DESCRIPTION
Bumps flow-bin to v0.110.1 and fixes one resulting flow error, which seems like it won't cause any issues in projects that depend on abstract-sdk.