### PR TITLE
fix: add missing projectId property to CollectionLayer type

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -585,6 +585,7 @@ export type CollectionLayer = {
   layerId: string,
   order: number,
   pageId: string,
+  projectId: string,
   sha: "latest" | string,
   useLatestCommit: boolean
 };


### PR DESCRIPTION
The latest version of flow (0.110.1) showed that we were using `collectionLayer.projectId` in Abstract, but it wasn't defined in the type in abstract-sdk.