### PR TITLE
fix: don't require abstract-cli in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "main": "lib/index.js",
   "types": "abstract-sdk.d.ts",
   "browser": {
+    "@elasticprojects/abstract-cli": false,
     "child_process": false,
     "fs": false
   },


### PR DESCRIPTION
The way we require abstract-cli doesn't work with webpack in browser environments. This change fixes webpack builds that use abstract-sdk. Thanks @amccloud for this suggestion.