### PR TITLE
fix: update commits.list method signature

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -201,7 +201,7 @@ interface Comments extends Endpoint {
       BranchDescriptor
       | CommitDescriptor
       | PageDescriptor
-      | LayerDescriptor & { pageId: string },
+      | LayerVersionDescriptor & { pageId: string },
     comment: NewComment
   ): Promise<Comment>;
 
@@ -209,7 +209,7 @@ interface Comments extends Endpoint {
     descriptor:
       BranchDescriptor
       | CommitDescriptor
-      | LayerDescriptor
+      | LayerVersionDescriptor
       | PageDescriptor,
     options?: ListOptions
   ): CursorPromise<Comment[]>;
@@ -217,17 +217,21 @@ interface Comments extends Endpoint {
 
 interface Commits extends Endpoint {
   info(
-    descriptor: CommitDescriptor | FileDescriptor | LayerDescriptor
+    descriptor: CommitDescriptor | FileDescriptor | LayerVersionDescriptor
   ): Promise<Commit>;
 
   list(
-    descriptor: CommitDescriptor | FileDescriptor | LayerDescriptor,
-    options?: { limit?: number }
+    descriptor: BranchDescriptor | FileDescriptor | LayerDescriptor,
+    options?: {
+      limit?: number,
+      startSHA?: string,
+      endSHA?: string
+    }
   ): Promise<Commit[]>;
 }
 
 interface Data extends Endpoint {
-  info(descriptor: LayerDescriptor): Promise<LayerDataset>;
+  info(descriptor: LayerVersionDescriptor): Promise<LayerDataset>;
 }
 
 interface Descriptors extends Endpoint {
@@ -241,7 +245,7 @@ interface Files extends Endpoint {
 }
 
 interface Layers extends Endpoint {
-  info(descriptor: LayerDescriptor): Promise<Layer>;
+  info(descriptor: LayerVersionDescriptor): Promise<Layer>;
   list(
     descriptor: FileDescriptor | PageDescriptor,
     options?: ListOptions
@@ -277,9 +281,9 @@ interface Pages extends Endpoint {
 }
 
 interface Previews extends Endpoint {
-  info(descriptor: LayerDescriptor): Promise<PreviewMeta>;
-  raw(descriptor: LayerDescriptor, options?: RawOptions): Promise<ArrayBuffer>;
-  url(descriptor: LayerDescriptor): Promise<string>;
+  info(descriptor: LayerVersionDescriptor): Promise<PreviewMeta>;
+  raw(descriptor: LayerVersionDescriptor, options?: RawOptions): Promise<ArrayBuffer>;
+  url(descriptor: LayerVersionDescriptor): Promise<string>;
 }
 
 interface Projects extends Endpoint {
@@ -370,7 +374,15 @@ type PageDescriptor = ObjectDescriptor & {
   pageId: string
 };
 
-type LayerDescriptor = ObjectDescriptor & {
+type LayerVersionDescriptor = ObjectDescriptor & {
+  fileId: string,
+  layerId: string
+};
+
+type LayerDescriptor = {
+  sha?: "latest" | string,
+  projectId: string,
+  branchId: string | "master"
   fileId: string,
   layerId: string
 };
@@ -735,7 +747,7 @@ type PageShare = BaseShare & {
 
 type LayerShare = BaseShare & {
   kind: "layer",
-  descriptor: LayerDescriptor,
+  descriptor: LayerVersionDescriptor,
   options: {
     mode?: "design" | "compare" | "build",
     public?: boolean,
@@ -788,7 +800,7 @@ type PageShareInput = BaseShareInput & PageDescriptor & {
   kind: "page"
 };
 
-type LayerShareInput = BaseShareInput & LayerDescriptor & {
+type LayerShareInput = BaseShareInput & LayerVersionDescriptor & {
   kind: "layer",
   options: {
     public: boolean,

--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -380,7 +380,6 @@ type LayerVersionDescriptor = ObjectDescriptor & {
 };
 
 type LayerDescriptor = {
-  sha?: "latest" | string,
   projectId: string,
   branchId: string | "master"
   fileId: string,

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -564,7 +564,7 @@ represents a bounding area on-top of the layer, this can be used to leave commen
 
 ![API][api-icon]
 
-`comments.list(BranchDescriptor | CommitDescriptor | PageDescriptor | LayerDescriptor): CursorPromise<Comment[]>`
+`comments.list(BranchDescriptor | CommitDescriptor | PageDescriptor | LayerVersionDescriptor): CursorPromise<Comment[]>`
 
 List the comments for a specific project
 ```js
@@ -604,7 +604,7 @@ abstract.comments.info({
 
 ![API][api-icon]
 
-`comments.create(BranchDescriptor | CommitDescriptor | LayerDescriptor, Comment): Promise<Comment>`
+`comments.create(BranchDescriptor | CommitDescriptor | LayerVersionDescriptor, Comment): Promise<Comment>`
 
 Create a comment on a branch
 
@@ -668,7 +668,7 @@ to identify which version of the object you would like.
 
 ![CLI][cli-icon] ![API][api-icon]
 
-`commits.list(BranchDescriptor | LayerDescriptor): Promise<Commit[]>`
+`commits.list(BranchDescriptor | FileDescriptor | LayerDescriptor, { limit?: number, startSha?: string, endSha?: string }): Promise<Commit[]>`
 
 List the commits for a specific branch
 
@@ -686,8 +686,7 @@ abstract.commits.list({
   projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78",
   branchId: "master",
   fileId: "51DE7CD1-ECDC-473C-B30E-62AE913743B7",
-  layerId: "CA420E64-08D0-4B96-B0F7-75AA316B6A19",
-  sha: "latest"
+  layerId: "CA420E64-08D0-4B96-B0F7-75AA316B6A19"
 });
 ```
 
@@ -695,7 +694,7 @@ abstract.commits.list({
 
 ![CLI][cli-icon] ![API][api-icon]
 
-`commits.info (FileDescriptor | LayerDescriptor | CommitDescriptor): Promise<Commit>`
+`commits.info (FileDescriptor | LayerVersionDescriptor | CommitDescriptor): Promise<Commit>`
 
 Load the commit info for a specific commit SHA on a branch
 
@@ -739,7 +738,7 @@ abstract.commits.info({
 
 ![CLI][cli-icon] ![API][api-icon]
 
-`data.info(LayerDescriptor): Promise<LayerDataset>`
+`data.info(LayerVersionDescriptor): Promise<LayerDataset>`
 
 ```js
 abstract.data.info({
@@ -893,7 +892,7 @@ abstract.layers.list({
 
 ![CLI][cli-icon] ![API][api-icon]
 
-`layers.info(LayerDescriptor): Promise<Layer>`
+`layers.info(LayerVersionDescriptor): Promise<Layer>`
 
 Load the info for a layer in a file at the latest commit on a branch
 
@@ -1120,7 +1119,7 @@ only available in PNG format.
 
 ![API][api-icon]
 
-`previews.raw(LayerDescriptor, { filename?: string, disableWrite?: boolean }): Promise<ArrayBuffer>`
+`previews.raw(LayerVersionDescriptor, { filename?: string, disableWrite?: boolean }): Promise<ArrayBuffer>`
 
 Retrieve a preview image for a layer at a specific commit and save it to disk. Files will be saved to the current working directory by default, but a custom `filename` option can be used to customize this location.
 
@@ -1162,7 +1161,7 @@ fs.writeFile(`preview.png`, Buffer.from(processedBuffer), (err) => {
 
 > Note: The `previews.url` method requires an environment with [URL.createObjectURL](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL). If you are using node, you will need to save the image to a file with [`previews.raw`](#retrieve-an-image-file)
 
-`previews.url(LayerDescriptor): Promise<string>`
+`previews.url(LayerVersionDescriptor): Promise<string>`
 
 > Get an image as a _temporary_ blob url which can be displayed directly in an image tag or downloaded. The url exists only as long as the current browser session and should not be saved to a database directly.
 
@@ -1180,7 +1179,7 @@ abstract.previews.url({
 
 ![API][api-icon]
 
-`previews.info(LayerDescriptor): Promise<Preview>`
+`previews.info(LayerVersionDescriptor): Promise<Preview>`
 
 Load the info for a layer preview
 
@@ -1642,6 +1641,18 @@ Reference for the parameters required to load resources with the Abstract SDK.
 ```
 
 ### LayerDescriptor
+
+```js
+{
+  projectId: string,
+  branchId: string | "master",
+  fileId: string,
+  layerId: string,
+  sha?: string | "latest"
+}
+```
+
+### LayerVersionDescriptor
 
 ```js
 {

--- a/src/endpoints/Comments.js
+++ b/src/endpoints/Comments.js
@@ -7,7 +7,7 @@ import type {
   CommentDescriptor,
   CommitDescriptor,
   CursorPromise,
-  LayerDescriptor,
+  LayerVersionDescriptor,
   ListOptions,
   NewComment,
   PageDescriptor
@@ -21,7 +21,7 @@ export default class Comments extends Endpoint {
       | CommitDescriptor
       | PageDescriptor
       | {|
-          ...$Exact<LayerDescriptor>,
+          ...$Exact<LayerVersionDescriptor>,
           pageId: string
         |},
     comment: NewComment
@@ -59,7 +59,7 @@ export default class Comments extends Endpoint {
     descriptor:
       | BranchDescriptor
       | CommitDescriptor
-      | LayerDescriptor
+      | LayerVersionDescriptor
       | PageDescriptor,
     options: ListOptions = {}
   ) {

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -1,15 +1,17 @@
 // @flow
 import querystring from "query-string";
 import type {
+  BranchDescriptor,
   Commit,
   CommitDescriptor,
   FileDescriptor,
-  LayerDescriptor
+  LayerDescriptor,
+  LayerVersionDescriptor
 } from "../types";
 import Endpoint from "./Endpoint";
 
 export default class Commits extends Endpoint {
-  info(descriptor: CommitDescriptor | FileDescriptor | LayerDescriptor) {
+  info(descriptor: CommitDescriptor | FileDescriptor | LayerVersionDescriptor) {
     return this.request<Promise<Commit>>({
       api: () => {
         return this.apiRequest(
@@ -33,8 +35,12 @@ export default class Commits extends Endpoint {
   }
 
   list(
-    descriptor: CommitDescriptor | FileDescriptor | LayerDescriptor,
-    options: { limit?: number } = {}
+    descriptor: BranchDescriptor | FileDescriptor | LayerDescriptor,
+    options: {
+      limit?: number,
+      startSHA?: string,
+      endSHA?: string
+    } = {}
   ) {
     return this.request<Promise<Commit[]>>({
       api: async () => {
@@ -43,6 +49,7 @@ export default class Commits extends Endpoint {
           fileId: descriptor.fileId && descriptor.fileId,
           layerId: descriptor.layerId && descriptor.layerId
         });
+
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}/branches/${descriptor.branchId}/commits?${query}`
         );
@@ -56,6 +63,8 @@ export default class Commits extends Endpoint {
           descriptor.branchId,
           ...(descriptor.fileId ? ["--file-id", descriptor.fileId] : []),
           ...(descriptor.layerId ? ["--layer-id", descriptor.layerId] : []),
+          ...(options.startSHA ? ["--start-sha", options.startSHA] : []),
+          ...(options.endSHA ? ["--end-sha", options.endSHA] : []),
           ...(options.limit ? ["--limit", options.limit.toString()] : [])
         ]);
         return response.commits;

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -35,7 +35,7 @@ export default class Commits extends Endpoint {
   }
 
   list(
-    descriptor: BranchDescriptor | FileDescriptor | LayerDescriptor,
+    descriptor: BranchDescriptor | LayerDescriptor,
     options: {
       limit?: number,
       startSHA?: string,

--- a/src/endpoints/Commits.test.js
+++ b/src/endpoints/Commits.test.js
@@ -40,8 +40,7 @@ describe("#list", () => {
         projectId: "project-id",
         branchId: "branch-id",
         fileId: "file-id",
-        layerId: "layer-id",
-        sha: "sha"
+        layerId: "layer-id"
       },
       { limit: 10, startSHA: "start-sha", endSHA: "end-sha" }
     );
@@ -49,15 +48,13 @@ describe("#list", () => {
     expect(response).toEqual([]);
   });
 
-  test("cli - file id", async () => {
-    mockCLI(["commits", "project-id", "branch-id", "--file-id", "file-id"], {
+  test("cli - branch id", async () => {
+    mockCLI(["commits", "project-id", "branch-id"], {
       commits: []
     });
     const response = await CLI_CLIENT.commits.list({
       projectId: "project-id",
-      branchId: "branch-id",
-      fileId: "file-id",
-      sha: "sha"
+      branchId: "branch-id"
     });
 
     expect(response).toEqual([]);
@@ -69,6 +66,8 @@ describe("#list", () => {
         "commits",
         "project-id",
         "branch-id",
+        "--file-id",
+        "file-id",
         "--layer-id",
         "layer-id",
         "--start-sha",
@@ -85,6 +84,7 @@ describe("#list", () => {
         projectId: "project-id",
         branchId: "branch-id",
         layerId: "layer-id",
+        fileId: "file-id",
         sha: "sha"
       }: any),
       { limit: 10, startSHA: "start-sha", endSHA: "end-sha" }

--- a/src/endpoints/Commits.test.js
+++ b/src/endpoints/Commits.test.js
@@ -30,7 +30,7 @@ describe("#info", () => {
 describe("#list", () => {
   test("api", async () => {
     mockAPI(
-      "/projects/project-id/branches/branch-id/commits?fileId=file-id&layerId=layer-id&limit=10",
+      "/projects/project-id/branches/branch-id/commits?endSHA=end-sha&fileId=file-id&layerId=layer-id&limit=10&startSHA=start-sha",
       {
         commits: []
       }
@@ -43,7 +43,7 @@ describe("#list", () => {
         layerId: "layer-id",
         sha: "sha"
       },
-      { limit: 10 }
+      { limit: 10, startSHA: "start-sha", endSHA: "end-sha" }
     );
 
     expect(response).toEqual([]);
@@ -71,6 +71,10 @@ describe("#list", () => {
         "branch-id",
         "--layer-id",
         "layer-id",
+        "--start-sha",
+        "start-sha",
+        "--end-sha",
+        "end-sha",
         "--limit",
         "10"
       ],
@@ -83,7 +87,7 @@ describe("#list", () => {
         layerId: "layer-id",
         sha: "sha"
       }: any),
-      { limit: 10 }
+      { limit: 10, startSHA: "start-sha", endSHA: "end-sha" }
     );
 
     expect(response).toEqual([]);

--- a/src/endpoints/Data.js
+++ b/src/endpoints/Data.js
@@ -1,9 +1,9 @@
 // @flow
-import type { LayerDataset, LayerDescriptor } from "../types";
+import type { LayerDataset, LayerVersionDescriptor } from "../types";
 import Endpoint from "./Endpoint";
 
 export default class Data extends Endpoint {
-  async info(descriptor: LayerDescriptor) {
+  async info(descriptor: LayerVersionDescriptor) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );

--- a/src/endpoints/Layers.js
+++ b/src/endpoints/Layers.js
@@ -3,14 +3,14 @@ import querystring from "query-string";
 import type {
   FileDescriptor,
   Layer,
-  LayerDescriptor,
+  LayerVersionDescriptor,
   ListOptions,
   PageDescriptor
 } from "../types";
 import Endpoint from "./Endpoint";
 
 export default class Layers extends Endpoint {
-  async info(descriptor: LayerDescriptor) {
+  async info(descriptor: LayerVersionDescriptor) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );

--- a/src/endpoints/Previews.js
+++ b/src/endpoints/Previews.js
@@ -2,12 +2,12 @@
 /* global Blob */
 import { promises as fs } from "fs";
 import { FileAPIError } from "../errors";
-import type { LayerDescriptor, PreviewMeta, RawOptions } from "../types";
+import type { LayerVersionDescriptor, PreviewMeta, RawOptions } from "../types";
 import { isNodeEnvironment } from "../utils";
 import Endpoint from "./Endpoint";
 
 export default class Previews extends Endpoint {
-  async info(descriptor: LayerDescriptor) {
+  async info(descriptor: LayerVersionDescriptor) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );
@@ -22,7 +22,7 @@ export default class Previews extends Endpoint {
     });
   }
 
-  async raw(descriptor: LayerDescriptor, options: RawOptions = {}) {
+  async raw(descriptor: LayerVersionDescriptor, options: RawOptions = {}) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );
@@ -57,7 +57,7 @@ export default class Previews extends Endpoint {
     });
   }
 
-  async url(descriptor: LayerDescriptor) {
+  async url(descriptor: LayerVersionDescriptor) {
     if (typeof Blob === "undefined") {
       throw new FileAPIError();
     }

--- a/src/types.js
+++ b/src/types.js
@@ -59,6 +59,14 @@ export type PageDescriptor = {|
 |};
 
 export type LayerDescriptor = {|
+  sha?: "latest" | string,
+  projectId: string,
+  branchId: string | "master",
+  fileId: string,
+  layerId: string
+|};
+
+export type LayerVersionDescriptor = {|
   ...$Exact<ObjectDescriptor>,
   fileId: string,
   layerId: string
@@ -430,7 +438,7 @@ export type PageShare = {
 export type LayerShare = {
   ...BaseShare,
   kind: "layer",
-  descriptor: LayerDescriptor,
+  descriptor: LayerVersionDescriptor,
   options: {
     mode?: "design" | "compare" | "build",
     public?: boolean,
@@ -498,7 +506,7 @@ export type PageShareInput = {
 export type LayerShareInput = {
   kind: "layer",
   ...BaseShareInput,
-  ...LayerDescriptor,
+  ...LayerVersionDescriptor,
   options: {
     public: boolean,
     canInspect: boolean,

--- a/src/types.js
+++ b/src/types.js
@@ -59,7 +59,6 @@ export type PageDescriptor = {|
 |};
 
 export type LayerDescriptor = {|
-  sha?: "latest" | string,
   projectId: string,
   branchId: string | "master",
   fileId: string,


### PR DESCRIPTION
This pull request fixes the `commits.list` method by updating its signature accordingly. To help accomplish this, the existing `LayerDescriptor` was updated to be `sha`-less, and a new `LayerVersionDescriptor` was added for cases where a `sha` is actually required, which is still most cases.