### PR TITLE
feat: Remove need to pass branchId to load a commit

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -142,7 +142,7 @@ interface Activities extends Endpoint {
 interface Assets extends Endpoint {
   info(descriptor: AssetDescriptor, requestOptions: RequestOptions): Promise<Asset>;
   raw(descriptor: AssetDescriptor, options?: RawOptions): Promise<ArrayBuffer>;
-  commit(descriptor: CommitDescriptor, requestOptions: RequestOptions): Promise<Asset[]>;
+  commit(descriptor: BranchCommitDescriptor, requestOptions: RequestOptions): Promise<Asset[]>;
   file(descriptor: FileDescriptor, options?: ListOptions): CursorPromise<Asset[]>;
 }
 
@@ -156,7 +156,7 @@ interface Branches extends Endpoint {
 
 interface Changesets extends Endpoint {
   branch(descriptor: BranchDescriptor, requestOptions: RequestOptions): Promise<Changeset>;
-  commit(descriptor: CommitDescriptor, requestOptions: RequestOptions): Promise<Changeset>;
+  commit(descriptor: BranchCommitDescriptor, requestOptions: RequestOptions): Promise<Changeset>;
 }
 
 interface CollectionLayers extends Endpoint {
@@ -195,7 +195,7 @@ interface Comments extends Endpoint {
   create(
     descriptor:
       BranchDescriptor
-      | CommitDescriptor
+      | BranchCommitDescriptor
       | PageDescriptor
       | LayerVersionDescriptor & { pageId: string },
     comment: NewComment, requestOptions: RequestOptions
@@ -204,7 +204,7 @@ interface Comments extends Endpoint {
   list(
     descriptor:
       BranchDescriptor
-      | CommitDescriptor
+      | BranchCommitDescriptor
       | LayerVersionDescriptor
       | PageDescriptor,
     options?: ListOptions
@@ -213,7 +213,7 @@ interface Comments extends Endpoint {
 
 interface Commits extends Endpoint {
   info(
-    descriptor: CommitDescriptor | FileDescriptor | LayerVersionDescriptor, requestOptions: RequestOptions
+    descriptor: BranchCommitDescriptor | FileDescriptor | LayerVersionDescriptor, requestOptions: RequestOptions
   ): Promise<Commit>;
 
   list(
@@ -236,7 +236,7 @@ interface Descriptors extends Endpoint {
 
 interface Files extends Endpoint {
   info(descriptor: FileDescriptor, requestOptions: RequestOptions): Promise<File>;
-  list(descriptor: CommitDescriptor, requestOptions: RequestOptions): Promise<File[]>;
+  list(descriptor: BranchCommitDescriptor, requestOptions: RequestOptions): Promise<File[]>;
   raw(descriptor: FileDescriptor, options?: RawOptions): Promise<void>;
 }
 
@@ -350,7 +350,7 @@ type ObjectDescriptor = {
   branchId: string | "master"
 };
 
-type CommitDescriptor = {
+type BranchCommitDescriptor = {
   sha: string,
   projectId: string,
   branchId: string | "master"
@@ -722,7 +722,7 @@ type ProjectShare = BaseShare & {
 
 type CommitShare = BaseShare & {
   kind: "commit",
-  descriptor: CommitDescriptor
+  descriptor: BranchCommitDescriptor
 };
 
 type BranchShare = BaseShare & {
@@ -779,7 +779,7 @@ type ProjectShareInput = BaseShareInput & ProjectDescriptor & {
   kind: "project"
 };
 
-type CommitShareInput = BaseShareInput & CommitDescriptor & {
+type CommitShareInput = BaseShareInput & BranchCommitDescriptor & {
   kind: "commit"
 };
 

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -1684,6 +1684,15 @@ Reference for the parameters required to load resources with the Abstract SDK.
 }
 ```
 
+### CommitDescriptor
+
+```js
+{
+  projectId: string,
+  branchId: string | "master"
+}
+```
+
 ### FileDescriptor
 
 ```js

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -121,7 +121,7 @@ abstract.assets.file({
 
 ### List assets for a commit
 
-`assets.commit(CommitDescriptor, RequestOptions): Promise<Asset[]>`
+`assets.commit(BranchCommitDescriptor, RequestOptions): Promise<Asset[]>`
 
 List all assets generated for a commit
 
@@ -277,7 +277,7 @@ A changeset is a group of changes that together form a single, indivisible modif
 
 ![CLI][cli-icon] ![API][api-icon]
 
-`changesets.commit(CommitDescriptor, RequestOptions): Promise<Changeset>`
+`changesets.commit(BranchCommitDescriptor, RequestOptions): Promise<Changeset>`
 
 Load a changeset for a commit
 
@@ -564,7 +564,7 @@ represents a bounding area on-top of the layer, this can be used to leave commen
 
 ![API][api-icon]
 
-`comments.list(BranchDescriptor | CommitDescriptor | PageDescriptor | LayerVersionDescriptor, RequestOptions): CursorPromise<Comment[]>`
+`comments.list(BranchDescriptor | BranchCommitDescriptor | PageDescriptor | LayerVersionDescriptor, RequestOptions): CursorPromise<Comment[]>`
 
 List the comments for a specific project
 ```js
@@ -604,7 +604,7 @@ abstract.comments.info({
 
 ![API][api-icon]
 
-`comments.create(BranchDescriptor | CommitDescriptor | LayerVersionDescriptor, Comment, RequestOptions): Promise<Comment>`
+`comments.create(BranchDescriptor | BranchCommitDescriptor | LayerVersionDescriptor, Comment, RequestOptions): Promise<Comment>`
 
 Create a comment on a branch
 
@@ -701,7 +701,6 @@ Load the commit info for a specific commit SHA on a branch
 ```js
 abstract.commits.info({
   projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78",
-  branchId: "master",
   sha: "fb7e9b50da6c330fc43ffb369616f0cd1fa92cc2"
 });
 ```
@@ -1675,7 +1674,7 @@ Reference for the parameters required to load resources with the Abstract SDK.
 }
 ```
 
-### CommitDescriptor
+### BranchCommitDescriptor
 
 ```js
 {

--- a/src/endpoints/Assets.js
+++ b/src/endpoints/Assets.js
@@ -5,7 +5,7 @@ import { isNodeEnvironment } from "../util/helpers";
 import type {
   Asset,
   AssetDescriptor,
-  CommitDescriptor,
+  BranchCommitDescriptor,
   FileDescriptor,
   ListOptions,
   RawOptions,
@@ -28,7 +28,7 @@ export default class Assets extends Endpoint {
   }
 
   async commit(
-    descriptor: CommitDescriptor,
+    descriptor: BranchCommitDescriptor,
     requestOptions: RequestOptions = {}
   ) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(

--- a/src/endpoints/Changesets.js
+++ b/src/endpoints/Changesets.js
@@ -2,14 +2,14 @@
 import type {
   BranchDescriptor,
   Changeset,
-  CommitDescriptor,
+  BranchCommitDescriptor,
   RequestOptions
 } from "../types";
 import Endpoint from "../endpoints/Endpoint";
 
 export default class Changesets extends Endpoint {
   async commit(
-    descriptor: CommitDescriptor,
+    descriptor: BranchCommitDescriptor,
     requestOptions: RequestOptions = {}
   ) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(

--- a/src/endpoints/Comments.js
+++ b/src/endpoints/Comments.js
@@ -4,7 +4,7 @@ import type {
   BranchDescriptor,
   Comment,
   CommentDescriptor,
-  CommitDescriptor,
+  BranchCommitDescriptor,
   LayerVersionDescriptor,
   ListOptions,
   NewComment,
@@ -17,7 +17,7 @@ export default class Comments extends Endpoint {
   async create(
     descriptor:
       | BranchDescriptor
-      | CommitDescriptor
+      | BranchCommitDescriptor
       | PageDescriptor
       | {|
           ...$Exact<LayerVersionDescriptor>,
@@ -65,7 +65,7 @@ export default class Comments extends Endpoint {
   async list(
     descriptor:
       | BranchDescriptor
-      | CommitDescriptor
+      | BranchCommitDescriptor
       | LayerVersionDescriptor
       | PageDescriptor,
     options: ListOptions = {}

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -19,9 +19,15 @@ export default class Commits extends Endpoint {
     return this.configureRequest<Promise<Commit>>(
       {
         api: () => {
-          return this.apiRequest(
-            `projects/${descriptor.projectId}/branches/${descriptor.branchId}/commits/${descriptor.sha}`
-          );
+          // loading commits with a share token requires a branchId so this
+          // route is maintained for that circumstance
+          return descriptor.branchId
+            ? this.apiRequest(
+                `projects/${descriptor.projectId}/branches/${descriptor.branchId}/commits/${descriptor.sha}`
+              )
+            : this.apiRequest(
+                `projects/${descriptor.projectId}/commits/${descriptor.sha}`
+              );
         },
 
         cli: async () => {

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -3,6 +3,7 @@ import querystring from "query-string";
 import type {
   BranchDescriptor,
   Commit,
+  BranchCommitDescriptor,
   CommitDescriptor,
   FileDescriptor,
   LayerDescriptor,
@@ -13,7 +14,11 @@ import Endpoint from "../endpoints/Endpoint";
 
 export default class Commits extends Endpoint {
   info(
-    descriptor: CommitDescriptor | FileDescriptor | LayerVersionDescriptor,
+    descriptor:
+      | BranchCommitDescriptor
+      | CommitDescriptor
+      | FileDescriptor
+      | LayerVersionDescriptor,
     requestOptions: RequestOptions = {}
   ) {
     return this.configureRequest<Promise<Commit>>(

--- a/src/endpoints/Descriptors.js
+++ b/src/endpoints/Descriptors.js
@@ -1,13 +1,9 @@
 // @flow
-import type {
-  ObjectDescriptor,
-  BranchCommitDescriptor,
-  RequestOptions
-} from "../types";
+import type { ObjectDescriptor, RequestOptions } from "../types";
 import Endpoint from "../endpoints/Endpoint";
 
 export default class Descriptors extends Endpoint {
-  async getLatestDescriptor<T: ObjectDescriptor | BranchCommitDescriptor>(
+  async getLatestDescriptor<T: ObjectDescriptor>(
     descriptor: T,
     requestOptions: RequestOptions = {}
   ): Promise<T> {

--- a/src/endpoints/Descriptors.js
+++ b/src/endpoints/Descriptors.js
@@ -1,9 +1,13 @@
 // @flow
-import type { ObjectDescriptor, RequestOptions } from "../types";
+import type {
+  ObjectDescriptor,
+  BranchCommitDescriptor,
+  RequestOptions
+} from "../types";
 import Endpoint from "../endpoints/Endpoint";
 
 export default class Descriptors extends Endpoint {
-  async getLatestDescriptor<T: ObjectDescriptor>(
+  async getLatestDescriptor<T: ObjectDescriptor | BranchCommitDescriptor>(
     descriptor: T,
     requestOptions: RequestOptions = {}
   ): Promise<T> {

--- a/src/endpoints/Files.js
+++ b/src/endpoints/Files.js
@@ -1,6 +1,6 @@
 // @flow
 import type {
-  CommitDescriptor,
+  BranchCommitDescriptor,
   File,
   FileDescriptor,
   RawOptions,
@@ -44,7 +44,7 @@ export default class Files extends Endpoint {
   }
 
   async list(
-    descriptor: CommitDescriptor,
+    descriptor: BranchCommitDescriptor,
     requestOptions: RequestOptions = {}
   ) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(

--- a/src/types.js
+++ b/src/types.js
@@ -45,8 +45,7 @@ export type BranchCommitDescriptor = {|
 
 export type CommitDescriptor = {|
   sha: string,
-  projectId: string,
-  branchId?: string | "master"
+  projectId: string
 |};
 
 export type BranchDescriptor = {|

--- a/src/types.js
+++ b/src/types.js
@@ -37,10 +37,16 @@ export type ObjectDescriptor = {
   branchId: string | "master"
 };
 
-export type CommitDescriptor = {|
+export type BranchCommitDescriptor = {|
   sha: string,
   projectId: string,
   branchId: string | "master"
+|};
+
+export type CommitDescriptor = {|
+  sha: string,
+  projectId: string,
+  branchId?: string | "master"
 |};
 
 export type BranchDescriptor = {|
@@ -454,7 +460,7 @@ export type ProjectShare = {
 export type CommitShare = {
   ...BaseShare,
   kind: "commit",
-  descriptor: CommitDescriptor
+  descriptor: BranchCommitDescriptor
 };
 
 export type BranchShare = {
@@ -522,7 +528,7 @@ export type ProjectShareInput = {
 export type CommitShareInput = {
   kind: "commit",
   ...BaseShareInput,
-  ...CommitDescriptor
+  ...BranchCommitDescriptor
 };
 
 export type BranchShareInput = {

--- a/tests/endpoints/Commits.test.js
+++ b/tests/endpoints/Commits.test.js
@@ -9,6 +9,21 @@ import {
 describe("commits", () => {
   describe("info", () => {
     test("api", async () => {
+      mockAPI("/projects/project-id/commits/sha", {
+        sha: "sha"
+      });
+
+      const response = await API_CLIENT.commits.info({
+        projectId: "project-id",
+        sha: "sha"
+      });
+
+      expect(response).toEqual({
+        sha: "sha"
+      });
+    });
+
+    test("api - branch", async () => {
       mockAPI("/projects/project-id/branches/branch-id/commits/sha", {
         sha: "sha"
       });


### PR DESCRIPTION
BREAKING CHANGES

Depends on deployment of new API endpoint: https://github.com/goabstract/projects/pull/3735