### PR TITLE
fix: Incorrect casing on commits.list parameters

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -220,8 +220,8 @@ interface Commits extends Endpoint {
     descriptor: BranchDescriptor | FileDescriptor | LayerDescriptor,
     options?: RequestOptions & {
       limit?: number,
-      startSHA?: string,
-      endSHA?: string
+      startSha?: string,
+      endSha?: string
     }
   ): Promise<Commit[]>;
 }

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -54,19 +54,19 @@ export default class Commits extends Endpoint {
     options: {
       ...RequestOptions,
       limit?: number,
-      startSHA?: string,
-      endSHA?: string
+      startSha?: string,
+      endSha?: string
     } = {}
   ) {
-    const { limit, startSHA, endSHA, ...requestOptions } = options;
+    const { limit, startSha, endSha, ...requestOptions } = options;
 
     return this.configureRequest<Promise<Commit[]>>(
       {
         api: async () => {
           const query = querystring.stringify({
             limit,
-            startSHA,
-            endSHA,
+            startSha,
+            endSha,
             fileId: descriptor.fileId && descriptor.fileId,
             layerId: descriptor.layerId && descriptor.layerId
           });
@@ -85,8 +85,8 @@ export default class Commits extends Endpoint {
             descriptor.branchId,
             ...(descriptor.fileId ? ["--file-id", descriptor.fileId] : []),
             ...(descriptor.layerId ? ["--layer-id", descriptor.layerId] : []),
-            ...(options.startSHA ? ["--start-sha", options.startSHA] : []),
-            ...(options.endSHA ? ["--end-sha", options.endSHA] : []),
+            ...(options.startSha ? ["--start-sha", options.startSha] : []),
+            ...(options.endSha ? ["--end-sha", options.endSha] : []),
             ...(options.limit ? ["--limit", options.limit.toString()] : [])
           ]);
 

--- a/tests/endpoints/Commits.test.js
+++ b/tests/endpoints/Commits.test.js
@@ -61,7 +61,7 @@ describe("commits", () => {
   describe("list", () => {
     test("api", async () => {
       mockAPI(
-        "/projects/project-id/branches/branch-id/commits?endSHA=end-sha&fileId=file-id&layerId=layer-id&limit=10&startSHA=start-sha",
+        "/projects/project-id/branches/branch-id/commits?endSha=end-sha&fileId=file-id&layerId=layer-id&limit=10&startSha=start-sha",
         {
           commits: []
         }
@@ -76,8 +76,8 @@ describe("commits", () => {
         },
         {
           limit: 10,
-          startSHA: "start-sha",
-          endSHA: "end-sha"
+          startSha: "start-sha",
+          endSha: "end-sha"
         }
       );
 
@@ -129,8 +129,8 @@ describe("commits", () => {
         }: any),
         {
           limit: 10,
-          startSHA: "start-sha",
-          endSHA: "end-sha"
+          startSha: "start-sha",
+          endSha: "end-sha"
         }
       );
 


### PR DESCRIPTION
Note: The documentation already listed the camelCased version: https://sdk.abstract.com/docs/abstract-api/#list-all-commits