### PR TITLE
fix: move js-sha256 from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "flow-bin": "^0.110.1",
     "flow-copy-source": "^2.0.3",
     "jest": "^24.1.0",
-    "js-sha256": "^0.9.0",
     "nock": "^11.0.0",
     "prettier": "^1.14.2",
     "standard-version": "^6.0.1"
@@ -70,6 +69,7 @@
     "cross-fetch": "^3.0.1",
     "debug": "^4.0.1",
     "flow-typed": "^2.5.1",
+    "js-sha256": "^0.9.0",
     "query-string": "^6.1.0",
     "uuid": "^3.3.2"
   },


### PR DESCRIPTION
This pull request fixes an issue where `js-sh256` was specified as a `devDependency` instead of a `dependency`.

Fixes #177 