### PR TITLE
chore(release): 7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [7.0.1](https://github.com/goabstract/abstract-sdk/compare/v7.0.0...v7.0.1) (2019-12-16)
+
+
+### Bug Fixes
+
+* move js-sha256 from devDependencies to dependencies ([#178](https://github.com/goabstract/abstract-sdk/issues/178)) ([f9b93b3](https://github.com/goabstract/abstract-sdk/commit/f9b93b3))
+
+
+
 ## [7.0.0](https://github.com/goabstract/abstract-sdk/compare/v6.0.1...v7.0.0) (2019-12-14)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abstract-sdk",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Universal JavaScript bindings for the Abstract API and CLI",
   "keywords": [
     "abstract",


### PR DESCRIPTION
This pull request cuts `abstract-sdk@7.0.1` which includes a dependency fix.