### PR TITLE
fix: move request options internally

### DIFF
--- a/src/endpoints/Activities.js
+++ b/src/endpoints/Activities.js
@@ -14,14 +14,12 @@ import Endpoint from "../endpoints/Endpoint";
 
 export default class Activities extends Endpoint {
   info(descriptor: ActivityDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Activity>>(
-      {
-        api: () => {
-          return this.apiRequest(`activities/${descriptor.activityId}`);
-        }
+    return this.configureRequest<Promise<Activity>>({
+      api: () => {
+        return this.apiRequest(`activities/${descriptor.activityId}`);
       },
       requestOptions
-    );
+    });
   }
 
   list(

--- a/src/endpoints/Assets.js
+++ b/src/endpoints/Assets.js
@@ -15,16 +15,14 @@ import Endpoint from "../endpoints/Endpoint";
 
 export default class Assets extends Endpoint {
   info(descriptor: AssetDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Asset>>(
-      {
-        api: () => {
-          return this.apiRequest(
-            `projects/${descriptor.projectId}/assets/${descriptor.assetId}`
-          );
-        }
+    return this.configureRequest<Promise<Asset>>({
+      api: () => {
+        return this.apiRequest(
+          `projects/${descriptor.projectId}/assets/${descriptor.assetId}`
+        );
       },
       requestOptions
-    );
+    });
   }
 
   async commit(
@@ -35,20 +33,18 @@ export default class Assets extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<Asset[]>>(
-      {
-        api: async () => {
-          const query = querystring.stringify({ sha: latestDescriptor.sha });
+    return this.configureRequest<Promise<Asset[]>>({
+      api: async () => {
+        const query = querystring.stringify({ sha: latestDescriptor.sha });
 
-          const response = await this.apiRequest(
-            `projects/${latestDescriptor.projectId}/assets?${query}`
-          );
+        const response = await this.apiRequest(
+          `projects/${latestDescriptor.projectId}/assets?${query}`
+        );
 
-          return response.data.assets;
-        }
+        return response.data.assets;
       },
       requestOptions
-    );
+    });
   }
 
   file(descriptor: FileDescriptor, options: ListOptions = {}) {
@@ -76,42 +72,40 @@ export default class Assets extends Endpoint {
   raw(descriptor: AssetDescriptor, options: RawOptions = {}) {
     const { disableWrite, filename, ...requestOptions } = options;
 
-    return this.configureRequest<Promise<ArrayBuffer>>(
-      {
-        api: async () => {
-          const asset = await this.info(descriptor);
-          const assetUrl = await this.options.assetUrl;
-          const assetPath = asset.url.replace(
-            /^\S+:\/\/objects.goabstract.com\//,
-            ""
-          );
+    return this.configureRequest<Promise<ArrayBuffer>>({
+      api: async () => {
+        const asset = await this.info(descriptor);
+        const assetUrl = await this.options.assetUrl;
+        const assetPath = asset.url.replace(
+          /^\S+:\/\/objects.goabstract.com\//,
+          ""
+        );
 
-          const arrayBuffer = await this.apiRequest(
-            assetPath,
-            {
-              headers: {
-                Accept: undefined,
-                "Content-Type": undefined,
-                "Abstract-Api-Version": undefined
-              }
-            },
-            {
-              customHostname: assetUrl,
-              raw: true
+        const arrayBuffer = await this.apiRequest(
+          assetPath,
+          {
+            headers: {
+              Accept: undefined,
+              "Content-Type": undefined,
+              "Abstract-Api-Version": undefined
             }
-          );
-
-          /* istanbul ignore if */
-          if (isNodeEnvironment() && !disableWrite) {
-            const diskLocation =
-              filename || `${asset.layerName}.${asset.fileFormat}`;
-            fs.writeFile(diskLocation, Buffer.from(arrayBuffer));
+          },
+          {
+            customHostname: assetUrl,
+            raw: true
           }
+        );
 
-          return arrayBuffer;
+        /* istanbul ignore if */
+        if (isNodeEnvironment() && !disableWrite) {
+          const diskLocation =
+            filename || `${asset.layerName}.${asset.fileFormat}`;
+          fs.writeFile(diskLocation, Buffer.from(arrayBuffer));
         }
+
+        return arrayBuffer;
       },
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -10,25 +10,24 @@ import Endpoint from "../endpoints/Endpoint";
 
 export default class Branches extends Endpoint {
   info(descriptor: BranchDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Branch>>(
-      {
-        api: () => {
-          return this.apiRequest(
-            `projects/${descriptor.projectId}/branches/${descriptor.branchId}`
-          );
-        },
-
-        cli: () => {
-          return this.cliRequest([
-            "branch",
-            "load",
-            descriptor.projectId,
-            descriptor.branchId
-          ]);
-        }
+    return this.configureRequest<Promise<Branch>>({
+      api: () => {
+        return this.apiRequest(
+          `projects/${descriptor.projectId}/branches/${descriptor.branchId}`
+        );
       },
+
+      cli: () => {
+        return this.cliRequest([
+          "branch",
+          "load",
+          descriptor.projectId,
+          descriptor.branchId
+        ]);
+      },
+
       requestOptions
-    );
+    });
   }
 
   list(
@@ -40,29 +39,28 @@ export default class Branches extends Endpoint {
   ) {
     const { filter, ...requestOptions } = options;
 
-    return this.configureRequest<Promise<Branch[]>>(
-      {
-        api: async () => {
-          const query = querystring.stringify({ filter });
+    return this.configureRequest<Promise<Branch[]>>({
+      api: async () => {
+        const query = querystring.stringify({ filter });
 
-          const response = await this.apiRequest(
-            `projects/${descriptor.projectId}/branches/?${query}`
-          );
+        const response = await this.apiRequest(
+          `projects/${descriptor.projectId}/branches/?${query}`
+        );
 
-          return response.data.branches;
-        },
-
-        cli: async () => {
-          const response = await this.cliRequest([
-            "branches",
-            descriptor.projectId,
-            ...(filter ? ["--filter", filter] : [])
-          ]);
-
-          return response.branches;
-        }
+        return response.data.branches;
       },
+
+      cli: async () => {
+        const response = await this.cliRequest([
+          "branches",
+          descriptor.projectId,
+          ...(filter ? ["--filter", filter] : [])
+        ]);
+
+        return response.branches;
+      },
+
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Changesets.js
+++ b/src/endpoints/Changesets.js
@@ -16,59 +16,57 @@ export default class Changesets extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<Changeset>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/commits/${latestDescriptor.sha}/changeset`
-          );
+    return this.configureRequest<Promise<Changeset>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/commits/${latestDescriptor.sha}/changeset`
+        );
 
-          return response.changeset;
-        },
-
-        cli: async () => {
-          const response = await this.cliRequest([
-            "changeset",
-            latestDescriptor.projectId,
-            "--commit",
-            latestDescriptor.sha,
-            "--branch",
-            latestDescriptor.branchId
-          ]);
-
-          return response.changeset;
-        }
+        return response.changeset;
       },
+
+      cli: async () => {
+        const response = await this.cliRequest([
+          "changeset",
+          latestDescriptor.projectId,
+          "--commit",
+          latestDescriptor.sha,
+          "--branch",
+          latestDescriptor.branchId
+        ]);
+
+        return response.changeset;
+      },
+
       requestOptions
-    );
+    });
   }
 
   async branch(
     descriptor: BranchDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Changeset>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `projects/${descriptor.projectId}/branches/${descriptor.branchId}/changeset`
-          );
+    return this.configureRequest<Promise<Changeset>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `projects/${descriptor.projectId}/branches/${descriptor.branchId}/changeset`
+        );
 
-          return response.changeset;
-        },
-
-        cli: async () => {
-          const response = await this.cliRequest([
-            "changeset",
-            descriptor.projectId,
-            "--branch",
-            descriptor.branchId
-          ]);
-
-          return response.changeset;
-        }
+        return response.changeset;
       },
+
+      cli: async () => {
+        const response = await this.cliRequest([
+          "changeset",
+          descriptor.projectId,
+          "--branch",
+          descriptor.branchId
+        ]);
+
+        return response.changeset;
+      },
+
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/CollectionLayers.js
+++ b/src/endpoints/CollectionLayers.js
@@ -17,22 +17,20 @@ export default class CollectionLayers extends Endpoint {
   ) {
     layer = { ...layer, collectionId: descriptor.collectionId };
 
-    return this.configureRequest<Promise<CollectionLayer>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `projects/${descriptor.projectId}/collection_layers`,
-            {
-              method: "POST",
-              body: layer
-            }
-          );
+    return this.configureRequest<Promise<CollectionLayer>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `projects/${descriptor.projectId}/collection_layers`,
+          {
+            method: "POST",
+            body: layer
+          }
+        );
 
-          return response;
-        }
+        return response;
       },
       requestOptions
-    );
+    });
   }
 
   addMany(
@@ -45,46 +43,43 @@ export default class CollectionLayers extends Endpoint {
       return { ...collectionLayer, id: layerId };
     });
 
-    return this.configureRequest<Promise<CollectionLayer>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `projects/${descriptor.projectId}/collection_layers/create_many`,
-            {
-              method: "POST",
-              body: {
-                collectionId: descriptor.collectionId,
-                layers: collectionLayers
-              }
+    return this.configureRequest<Promise<CollectionLayer>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `projects/${descriptor.projectId}/collection_layers/create_many`,
+          {
+            method: "POST",
+            body: {
+              collectionId: descriptor.collectionId,
+              layers: collectionLayers
             }
-          );
+          }
+        );
 
-          return response.data;
-        }
+        return response.data;
       },
       requestOptions
-    );
+    });
   }
 
   remove(
     descriptor: CollectionLayerDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<void>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `projects/${descriptor.projectId}/collection_layers/${descriptor.collectionLayerId}`,
-            {
-              method: "DELETE"
-            }
-          );
+    return this.configureRequest<Promise<void>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `projects/${descriptor.projectId}/collection_layers/${descriptor.collectionLayerId}`,
+          {
+            method: "DELETE"
+          }
+        );
 
-          return response;
-        }
+        return response;
       },
+
       requestOptions
-    );
+    });
   }
 
   move(
@@ -92,22 +87,20 @@ export default class CollectionLayers extends Endpoint {
     order: number,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<CollectionLayer[]>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `projects/${descriptor.projectId}/collection_layers/${descriptor.collectionLayerId}/move`,
-            {
-              method: "POST",
-              body: { order }
-            }
-          );
+    return this.configureRequest<Promise<CollectionLayer[]>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `projects/${descriptor.projectId}/collection_layers/${descriptor.collectionLayerId}/move`,
+          {
+            method: "POST",
+            body: { order }
+          }
+        );
 
-          return response;
-        }
+        return response;
       },
       requestOptions
-    );
+    });
   }
 
   update(
@@ -115,21 +108,19 @@ export default class CollectionLayers extends Endpoint {
     layer: UpdatedCollectionLayer,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<CollectionLayer>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `projects/${descriptor.projectId}/collection_layers/${descriptor.collectionLayerId}`,
-            {
-              method: "PUT",
-              body: layer
-            }
-          );
+    return this.configureRequest<Promise<CollectionLayer>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `projects/${descriptor.projectId}/collection_layers/${descriptor.collectionLayerId}`,
+          {
+            method: "PUT",
+            body: layer
+          }
+        );
 
-          return response;
-        }
+        return response;
       },
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Collections.js
+++ b/src/endpoints/Collections.js
@@ -19,22 +19,20 @@ export default class Collections extends Endpoint {
     collection: NewCollection,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Collection>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `projects/${descriptor.projectId}/collections`,
-            {
-              method: "POST",
-              body: collection
-            }
-          );
+    return this.configureRequest<Promise<Collection>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `projects/${descriptor.projectId}/collections`,
+          {
+            method: "POST",
+            body: collection
+          }
+        );
 
-          return response.data;
-        }
+        return response.data;
       },
       requestOptions
-    );
+    });
   }
 
   info(
@@ -46,38 +44,37 @@ export default class Collections extends Endpoint {
   ) {
     const { layersPerCollection, ...requestOptions } = options;
 
-    return this.configureRequest<Promise<CollectionResponse>>(
-      {
-        api: async () => {
-          const query = querystring.stringify({ layersPerCollection });
-          const response = await this.apiRequest(
-            `projects/${descriptor.projectId}/collections/${descriptor.collectionId}?${query}`
-          );
+    return this.configureRequest<Promise<CollectionResponse>>({
+      api: async () => {
+        const query = querystring.stringify({ layersPerCollection });
+        const response = await this.apiRequest(
+          `projects/${descriptor.projectId}/collections/${descriptor.collectionId}?${query}`
+        );
 
-          const { collections, ...meta } = response.data;
-          return {
-            collection: collections[0],
-            ...meta
-          };
-        },
-
-        cli: async () => {
-          const response = await this.cliRequest([
-            "collection",
-            "load",
-            descriptor.projectId,
-            descriptor.collectionId
-          ]);
-
-          const { collections, ...meta } = response.data;
-          return {
-            collection: collections[0],
-            ...meta
-          };
-        }
+        const { collections, ...meta } = response.data;
+        return {
+          collection: collections[0],
+          ...meta
+        };
       },
+
+      cli: async () => {
+        const response = await this.cliRequest([
+          "collection",
+          "load",
+          descriptor.projectId,
+          descriptor.collectionId
+        ]);
+
+        const { collections, ...meta } = response.data;
+        return {
+          collection: collections[0],
+          ...meta
+        };
+      },
+
       requestOptions
-    );
+    });
   }
 
   list(
@@ -89,34 +86,33 @@ export default class Collections extends Endpoint {
   ) {
     const { layersPerCollection, ...requestOptions } = options;
 
-    return this.configureRequest<Promise<CollectionsResponse>>(
-      {
-        api: async () => {
-          const { projectId, ...sanitizedDescriptor } = descriptor;
-          const query = querystring.stringify({
-            ...sanitizedDescriptor,
-            layersPerCollection
-          });
+    return this.configureRequest<Promise<CollectionsResponse>>({
+      api: async () => {
+        const { projectId, ...sanitizedDescriptor } = descriptor;
+        const query = querystring.stringify({
+          ...sanitizedDescriptor,
+          layersPerCollection
+        });
 
-          const response = await this.apiRequest(
-            `projects/${projectId}/collections?${query}`
-          );
+        const response = await this.apiRequest(
+          `projects/${projectId}/collections?${query}`
+        );
 
-          return response.data;
-        },
-
-        cli: async () => {
-          const response = await this.cliRequest([
-            "collections",
-            descriptor.projectId,
-            ...(descriptor.branchId ? ["--branch", descriptor.branchId] : [])
-          ]);
-
-          return response.data;
-        }
+        return response.data;
       },
+
+      cli: async () => {
+        const response = await this.cliRequest([
+          "collections",
+          descriptor.projectId,
+          ...(descriptor.branchId ? ["--branch", descriptor.branchId] : [])
+        ]);
+
+        return response.data;
+      },
+
       requestOptions
-    );
+    });
   }
 
   update(
@@ -124,21 +120,19 @@ export default class Collections extends Endpoint {
     collection: UpdatedCollection,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Collection>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `projects/${descriptor.projectId}/collections/${descriptor.collectionId}`,
-            {
-              method: "PUT",
-              body: collection
-            }
-          );
+    return this.configureRequest<Promise<Collection>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `projects/${descriptor.projectId}/collections/${descriptor.collectionId}`,
+          {
+            method: "PUT",
+            body: collection
+          }
+        );
 
-          return response.data;
-        }
+        return response.data;
       },
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Comments.js
+++ b/src/endpoints/Comments.js
@@ -32,34 +32,30 @@ export default class Comments extends Endpoint {
       );
     }
 
-    return this.configureRequest<Promise<Comment>>(
-      {
-        api: async () => {
-          const body = {
-            ...comment,
-            ...descriptor,
-            commitSha: descriptor.sha || undefined
-          };
+    return this.configureRequest<Promise<Comment>>({
+      api: async () => {
+        const body = {
+          ...comment,
+          ...descriptor,
+          commitSha: descriptor.sha || undefined
+        };
 
-          return this.apiRequest("comments", {
-            method: "POST",
-            body
-          });
-        }
+        return this.apiRequest("comments", {
+          method: "POST",
+          body
+        });
       },
       requestOptions
-    );
+    });
   }
 
   info(descriptor: CommentDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Comment>>(
-      {
-        api: () => {
-          return this.apiRequest(`comments/${descriptor.commentId}`);
-        }
+    return this.configureRequest<Promise<Comment>>({
+      api: () => {
+        return this.apiRequest(`comments/${descriptor.commentId}`);
       },
       requestOptions
-    );
+    });
   }
 
   async list(

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -21,32 +21,31 @@ export default class Commits extends Endpoint {
       | LayerVersionDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Commit>>(
-      {
-        api: () => {
-          // loading commits with a share token requires a branchId so this
-          // route is maintained for that circumstance
-          return descriptor.branchId
-            ? this.apiRequest(
-                `projects/${descriptor.projectId}/branches/${descriptor.branchId}/commits/${descriptor.sha}`
-              )
-            : this.apiRequest(
-                `projects/${descriptor.projectId}/commits/${descriptor.sha}`
-              );
-        },
-
-        cli: async () => {
-          const response = await this.cliRequest([
-            "commit",
-            descriptor.projectId,
-            descriptor.sha
-          ]);
-
-          return response.commit;
-        }
+    return this.configureRequest<Promise<Commit>>({
+      api: () => {
+        // loading commits with a share token requires a branchId so this
+        // route is maintained for that circumstance
+        return descriptor.branchId
+          ? this.apiRequest(
+              `projects/${descriptor.projectId}/branches/${descriptor.branchId}/commits/${descriptor.sha}`
+            )
+          : this.apiRequest(
+              `projects/${descriptor.projectId}/commits/${descriptor.sha}`
+            );
       },
+
+      cli: async () => {
+        const response = await this.cliRequest([
+          "commit",
+          descriptor.projectId,
+          descriptor.sha
+        ]);
+
+        return response.commit;
+      },
+
       requestOptions
-    );
+    });
   }
 
   list(
@@ -60,40 +59,39 @@ export default class Commits extends Endpoint {
   ) {
     const { limit, startSha, endSha, ...requestOptions } = options;
 
-    return this.configureRequest<Promise<Commit[]>>(
-      {
-        api: async () => {
-          const query = querystring.stringify({
-            limit,
-            startSha,
-            endSha,
-            fileId: descriptor.fileId && descriptor.fileId,
-            layerId: descriptor.layerId && descriptor.layerId
-          });
+    return this.configureRequest<Promise<Commit[]>>({
+      api: async () => {
+        const query = querystring.stringify({
+          limit,
+          startSha,
+          endSha,
+          fileId: descriptor.fileId && descriptor.fileId,
+          layerId: descriptor.layerId && descriptor.layerId
+        });
 
-          const response = await this.apiRequest(
-            `projects/${descriptor.projectId}/branches/${descriptor.branchId}/commits?${query}`
-          );
+        const response = await this.apiRequest(
+          `projects/${descriptor.projectId}/branches/${descriptor.branchId}/commits?${query}`
+        );
 
-          return response.commits;
-        },
-
-        cli: async () => {
-          const response = await this.cliRequest([
-            "commits",
-            descriptor.projectId,
-            descriptor.branchId,
-            ...(descriptor.fileId ? ["--file-id", descriptor.fileId] : []),
-            ...(descriptor.layerId ? ["--layer-id", descriptor.layerId] : []),
-            ...(options.startSha ? ["--start-sha", options.startSha] : []),
-            ...(options.endSha ? ["--end-sha", options.endSha] : []),
-            ...(options.limit ? ["--limit", options.limit.toString()] : [])
-          ]);
-
-          return response.commits;
-        }
+        return response.commits;
       },
+
+      cli: async () => {
+        const response = await this.cliRequest([
+          "commits",
+          descriptor.projectId,
+          descriptor.branchId,
+          ...(descriptor.fileId ? ["--file-id", descriptor.fileId] : []),
+          ...(descriptor.layerId ? ["--layer-id", descriptor.layerId] : []),
+          ...(options.startSha ? ["--start-sha", options.startSha] : []),
+          ...(options.endSha ? ["--end-sha", options.endSha] : []),
+          ...(options.limit ? ["--limit", options.limit.toString()] : [])
+        ]);
+
+        return response.commits;
+      },
+
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Data.js
+++ b/src/endpoints/Data.js
@@ -15,26 +15,25 @@ export default class Data extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<LayerDataset>>(
-      {
-        api: () => {
-          return this.apiRequest(
-            `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/commits/${latestDescriptor.sha}/files/${latestDescriptor.fileId}/layers/${latestDescriptor.layerId}/data`
-          );
-        },
-
-        cli: () => {
-          return this.cliRequest([
-            "layer",
-            "data",
-            latestDescriptor.projectId,
-            latestDescriptor.sha,
-            latestDescriptor.fileId,
-            latestDescriptor.layerId
-          ]);
-        }
+    return this.configureRequest<Promise<LayerDataset>>({
+      api: () => {
+        return this.apiRequest(
+          `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/commits/${latestDescriptor.sha}/files/${latestDescriptor.fileId}/layers/${latestDescriptor.layerId}/data`
+        );
       },
+
+      cli: () => {
+        return this.cliRequest([
+          "layer",
+          "data",
+          latestDescriptor.projectId,
+          latestDescriptor.sha,
+          latestDescriptor.fileId,
+          latestDescriptor.layerId
+        ]);
+      },
+
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -16,8 +16,7 @@ import {
 import type {
   ApiRequestOptions,
   CommandOptions,
-  RequestConfig,
-  RequestOptions
+  RequestConfig
 } from "../types";
 
 const logAPIRequest = log.extend("AbstractAPI:request");

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -35,13 +35,11 @@ export default class Endpoint {
     this.options = options;
   }
 
-  configureRequest<T>(
-    config: RequestConfig<T>,
-    requestOptions: RequestOptions = {}
-  ): T {
+  configureRequest<T>(config: RequestConfig<T>): T {
     const makeRequest = async () => {
       let response;
       const errors = {};
+      const requestOptions = config.requestOptions || {};
       const transportMode =
         requestOptions.transportMode || this.options.transportMode;
 

--- a/src/endpoints/Files.js
+++ b/src/endpoints/Files.js
@@ -16,31 +16,30 @@ export default class Files extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<File>>(
-      {
-        api: async () => {
-          const { fileId, ...branchDescriptor } = latestDescriptor;
-          const files = await this.list(branchDescriptor);
-          const file = files.find(file => file.id === latestDescriptor.fileId);
-          if (!file) {
-            throw new NotFoundError(`fileId=${latestDescriptor.fileId}`);
-          }
-          return file;
-        },
-
-        cli: async () => {
-          const response = await this.cliRequest([
-            "file",
-            latestDescriptor.projectId,
-            latestDescriptor.sha,
-            latestDescriptor.fileId
-          ]);
-
-          return response.file;
+    return this.configureRequest<Promise<File>>({
+      api: async () => {
+        const { fileId, ...branchDescriptor } = latestDescriptor;
+        const files = await this.list(branchDescriptor);
+        const file = files.find(file => file.id === latestDescriptor.fileId);
+        if (!file) {
+          throw new NotFoundError(`fileId=${latestDescriptor.fileId}`);
         }
+        return file;
       },
+
+      cli: async () => {
+        const response = await this.cliRequest([
+          "file",
+          latestDescriptor.projectId,
+          latestDescriptor.sha,
+          latestDescriptor.fileId
+        ]);
+
+        return response.file;
+      },
+
       requestOptions
-    );
+    });
   }
 
   async list(
@@ -51,28 +50,27 @@ export default class Files extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<File[]>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/files`
-          );
+    return this.configureRequest<Promise<File[]>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/files`
+        );
 
-          return response.files;
-        },
-
-        cli: async () => {
-          const response = await this.cliRequest([
-            "files",
-            latestDescriptor.projectId,
-            latestDescriptor.sha
-          ]);
-
-          return response.files;
-        }
+        return response.files;
       },
+
+      cli: async () => {
+        const response = await this.cliRequest([
+          "files",
+          latestDescriptor.projectId,
+          latestDescriptor.sha
+        ]);
+
+        return response.files;
+      },
+
       requestOptions
-    );
+    });
   }
 
   async raw(descriptor: FileDescriptor, options: RawOptions = {}) {
@@ -81,26 +79,24 @@ export default class Files extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<void>>(
-      {
-        cli: async () => {
-          /* istanbul ignore if */
-          if (!isNodeEnvironment() || disableWrite) {
-            return;
-          }
-
-          await this.cliRequest([
-            "file",
-            "export",
-            latestDescriptor.fileId,
-            filename || process.cwd(),
-            `--project-id=${latestDescriptor.projectId}`,
-            `--branch-id=${latestDescriptor.branchId}`,
-            `--sha=${latestDescriptor.sha}`
-          ]);
+    return this.configureRequest<Promise<void>>({
+      cli: async () => {
+        /* istanbul ignore if */
+        if (!isNodeEnvironment() || disableWrite) {
+          return;
         }
+
+        await this.cliRequest([
+          "file",
+          "export",
+          latestDescriptor.fileId,
+          filename || process.cwd(),
+          `--project-id=${latestDescriptor.projectId}`,
+          `--branch-id=${latestDescriptor.branchId}`,
+          `--sha=${latestDescriptor.sha}`
+        ]);
       },
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Layers.js
+++ b/src/endpoints/Layers.js
@@ -19,35 +19,34 @@ export default class Layers extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<Layer>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/commits/${latestDescriptor.sha}/files/${latestDescriptor.fileId}/layers/${latestDescriptor.layerId}`
-          );
+    return this.configureRequest<Promise<Layer>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/commits/${latestDescriptor.sha}/files/${latestDescriptor.fileId}/layers/${latestDescriptor.layerId}`
+        );
 
-          return {
-            ...response.layer,
-            _file: response.file,
-            _page: response.page
-          };
-        },
-
-        cli: async () => {
-          const response = await this.cliRequest([
-            "layer",
-            "meta",
-            latestDescriptor.projectId,
-            latestDescriptor.sha,
-            latestDescriptor.fileId,
-            latestDescriptor.layerId
-          ]);
-
-          return response.layer;
-        }
+        return {
+          ...response.layer,
+          _file: response.file,
+          _page: response.page
+        };
       },
+
+      cli: async () => {
+        const response = await this.cliRequest([
+          "layer",
+          "meta",
+          latestDescriptor.projectId,
+          latestDescriptor.sha,
+          latestDescriptor.fileId,
+          latestDescriptor.layerId
+        ]);
+
+        return response.layer;
+      },
+
       requestOptions
-    );
+    });
   }
 
   async list(
@@ -59,34 +58,33 @@ export default class Layers extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<Layer[]>>(
-      {
-        api: async () => {
-          const query = querystring.stringify({
-            ...latestDescriptor,
-            limit,
-            offset
-          });
+    return this.configureRequest<Promise<Layer[]>>({
+      api: async () => {
+        const query = querystring.stringify({
+          ...latestDescriptor,
+          limit,
+          offset
+        });
 
-          const response = await this.apiRequest(
-            `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/files/${latestDescriptor.fileId}/layers?${query}`
-          );
+        const response = await this.apiRequest(
+          `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/files/${latestDescriptor.fileId}/layers?${query}`
+        );
 
-          return response.layers;
-        },
-
-        cli: async () => {
-          const response = await this.cliRequest([
-            "layers",
-            latestDescriptor.projectId,
-            latestDescriptor.sha,
-            latestDescriptor.fileId
-          ]);
-
-          return response.layers;
-        }
+        return response.layers;
       },
+
+      cli: async () => {
+        const response = await this.cliRequest([
+          "layers",
+          latestDescriptor.projectId,
+          latestDescriptor.sha,
+          latestDescriptor.fileId
+        ]);
+
+        return response.layers;
+      },
+
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Memberships.js
+++ b/src/endpoints/Memberships.js
@@ -14,49 +14,45 @@ export default class Memberships extends Endpoint {
     descriptor: OrganizationMembershipDescriptor | ProjectMembershipDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Membership>>(
-      {
-        api: async () => {
-          let url = "";
+    return this.configureRequest<Promise<Membership>>({
+      api: async () => {
+        let url = "";
 
-          if (descriptor.organizationId) {
-            url = `organizations/${descriptor.organizationId}/memberships/${descriptor.userId}`;
-          }
-
-          if (descriptor.projectId) {
-            url = `projects/${descriptor.projectId}/memberships/${descriptor.userId}`;
-          }
-
-          const response = await this.apiRequest(url);
-          return response.data.projectMembership || response.data;
+        if (descriptor.organizationId) {
+          url = `organizations/${descriptor.organizationId}/memberships/${descriptor.userId}`;
         }
+
+        if (descriptor.projectId) {
+          url = `projects/${descriptor.projectId}/memberships/${descriptor.userId}`;
+        }
+
+        const response = await this.apiRequest(url);
+        return response.data.projectMembership || response.data;
       },
       requestOptions
-    );
+    });
   }
 
   list(
     descriptor: OrganizationDescriptor | ProjectDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Membership[]>>(
-      {
-        api: async () => {
-          let url = "";
+    return this.configureRequest<Promise<Membership[]>>({
+      api: async () => {
+        let url = "";
 
-          if (descriptor.organizationId) {
-            url = `organizations/${descriptor.organizationId}/memberships`;
-          }
-
-          if (descriptor.projectId) {
-            url = `projects/${descriptor.projectId}/memberships`;
-          }
-
-          const response = await this.apiRequest(url);
-          return response.data;
+        if (descriptor.organizationId) {
+          url = `organizations/${descriptor.organizationId}/memberships`;
         }
+
+        if (descriptor.projectId) {
+          url = `projects/${descriptor.projectId}/memberships`;
+        }
+
+        const response = await this.apiRequest(url);
+        return response.data;
       },
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Notifications.js
+++ b/src/endpoints/Notifications.js
@@ -14,14 +14,12 @@ export default class Notifications extends Endpoint {
     descriptor: NotificationDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Notification>>(
-      {
-        api: () => {
-          return this.apiRequest(`notifications/${descriptor.notificationId}`);
-        }
+    return this.configureRequest<Promise<Notification>>({
+      api: () => {
+        return this.apiRequest(`notifications/${descriptor.notificationId}`);
       },
       requestOptions
-    );
+    });
   }
 
   list(descriptor: OrganizationDescriptor, options: ListOptions = {}) {

--- a/src/endpoints/Organizations.js
+++ b/src/endpoints/Organizations.js
@@ -11,29 +11,25 @@ export default class Organizations extends Endpoint {
     descriptor: OrganizationDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Organization>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `organizations/${descriptor.organizationId}`
-          );
+    return this.configureRequest<Promise<Organization>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `organizations/${descriptor.organizationId}`
+        );
 
-          return response.data;
-        }
+        return response.data;
       },
       requestOptions
-    );
+    });
   }
 
   list(requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Organization[]>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest("organizations");
-          return response.data;
-        }
+    return this.configureRequest<Promise<Organization[]>>({
+      api: async () => {
+        const response = await this.apiRequest("organizations");
+        return response.data;
       },
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Pages.js
+++ b/src/endpoints/Pages.js
@@ -14,30 +14,29 @@ export default class Pages extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<Page>>(
-      {
-        api: async () => {
-          const { pageId, ...fileDescriptor } = latestDescriptor;
-          const pages = await this.list(fileDescriptor);
-          const page = pages.find(page => page.id === pageId);
-          if (!page) {
-            throw new NotFoundError(`pageId=${pageId}`);
-          }
-          return page;
-        },
-
-        cli: async () => {
-          const { pageId, ...fileDescriptor } = latestDescriptor;
-          const pages = await this.list(fileDescriptor);
-          const page = pages.find(page => page.id === pageId);
-          if (!page) {
-            throw new NotFoundError(`pageId=${pageId}`);
-          }
-          return page;
+    return this.configureRequest<Promise<Page>>({
+      api: async () => {
+        const { pageId, ...fileDescriptor } = latestDescriptor;
+        const pages = await this.list(fileDescriptor);
+        const page = pages.find(page => page.id === pageId);
+        if (!page) {
+          throw new NotFoundError(`pageId=${pageId}`);
         }
+        return page;
       },
+
+      cli: async () => {
+        const { pageId, ...fileDescriptor } = latestDescriptor;
+        const pages = await this.list(fileDescriptor);
+        const page = pages.find(page => page.id === pageId);
+        if (!page) {
+          throw new NotFoundError(`pageId=${pageId}`);
+        }
+        return page;
+      },
+
       requestOptions
-    );
+    });
   }
 
   async list(descriptor: FileDescriptor, requestOptions: RequestOptions = {}) {
@@ -45,27 +44,26 @@ export default class Pages extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<Page[]>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/files/${latestDescriptor.fileId}/pages`
-          );
+    return this.configureRequest<Promise<Page[]>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/files/${latestDescriptor.fileId}/pages`
+        );
 
-          return response.pages;
-        },
-
-        cli: async () => {
-          const response = await this.cliRequest([
-            "files",
-            latestDescriptor.projectId,
-            latestDescriptor.sha
-          ]);
-
-          return response.pages;
-        }
+        return response.pages;
       },
+
+      cli: async () => {
+        const response = await this.cliRequest([
+          "files",
+          latestDescriptor.projectId,
+          latestDescriptor.sha
+        ]);
+
+        return response.pages;
+      },
+
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Previews.js
+++ b/src/endpoints/Previews.js
@@ -20,18 +20,16 @@ export default class Previews extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<PreviewMeta>>(
-      {
-        api: async () => ({
-          webUrl: `${await this.options.webUrl}/projects/${
-            latestDescriptor.projectId
-          }/commits/${latestDescriptor.sha}/files/${
-            latestDescriptor.fileId
-          }/layers/${latestDescriptor.layerId}`
-        })
-      },
+    return this.configureRequest<Promise<PreviewMeta>>({
+      api: async () => ({
+        webUrl: `${await this.options.webUrl}/projects/${
+          latestDescriptor.projectId
+        }/commits/${latestDescriptor.sha}/files/${
+          latestDescriptor.fileId
+        }/layers/${latestDescriptor.layerId}`
+      }),
       requestOptions
-    );
+    });
   }
 
   async raw(descriptor: LayerVersionDescriptor, options: RawOptions = {}) {
@@ -40,36 +38,34 @@ export default class Previews extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<ArrayBuffer>>(
-      {
-        api: async () => {
-          const previewUrl = await this.options.previewUrl;
-          const arrayBuffer = await this.apiRequest(
-            `projects/${latestDescriptor.projectId}/commits/${latestDescriptor.sha}/files/${latestDescriptor.fileId}/layers/${latestDescriptor.layerId}`,
-            {
-              headers: {
-                Accept: undefined,
-                "Content-Type": undefined,
-                "Abstract-Api-Version": undefined
-              }
-            },
-            {
-              customHostname: previewUrl,
-              raw: true
+    return this.configureRequest<Promise<ArrayBuffer>>({
+      api: async () => {
+        const previewUrl = await this.options.previewUrl;
+        const arrayBuffer = await this.apiRequest(
+          `projects/${latestDescriptor.projectId}/commits/${latestDescriptor.sha}/files/${latestDescriptor.fileId}/layers/${latestDescriptor.layerId}`,
+          {
+            headers: {
+              Accept: undefined,
+              "Content-Type": undefined,
+              "Abstract-Api-Version": undefined
             }
-          );
-
-          /* istanbul ignore if */
-          if (isNodeEnvironment() && !disableWrite) {
-            const diskLocation = filename || `${latestDescriptor.layerId}.png`;
-            fs.writeFile(diskLocation, Buffer.from(arrayBuffer));
+          },
+          {
+            customHostname: previewUrl,
+            raw: true
           }
+        );
 
-          return arrayBuffer;
+        /* istanbul ignore if */
+        if (isNodeEnvironment() && !disableWrite) {
+          const diskLocation = filename || `${latestDescriptor.layerId}.png`;
+          fs.writeFile(diskLocation, Buffer.from(arrayBuffer));
         }
+
+        return arrayBuffer;
       },
       requestOptions
-    );
+    });
   }
 
   async url(

--- a/src/endpoints/Projects.js
+++ b/src/endpoints/Projects.js
@@ -14,19 +14,17 @@ const headers = {
 
 export default class Projects extends Endpoint {
   info(descriptor: ProjectDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Project>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `projects/${descriptor.projectId}`,
-            { headers }
-          );
+    return this.configureRequest<Promise<Project>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `projects/${descriptor.projectId}`,
+          { headers }
+        );
 
-          return response.data;
-        }
+        return response.data;
       },
       requestOptions
-    );
+    });
   }
 
   list(
@@ -39,28 +37,26 @@ export default class Projects extends Endpoint {
   ) {
     const { filter, sectionId, ...requestOptions } = options;
 
-    return this.configureRequest<Promise<Project[]>>(
-      {
-        api: async () => {
-          const query = querystring.stringify({
-            ...descriptor,
-            filter,
-            sectionId
-          });
-          const response = await this.apiRequest(`projects?${query}`, {
-            headers
-          });
+    return this.configureRequest<Promise<Project[]>>({
+      api: async () => {
+        const query = querystring.stringify({
+          ...descriptor,
+          filter,
+          sectionId
+        });
+        const response = await this.apiRequest(`projects?${query}`, {
+          headers
+        });
 
-          if (sectionId) {
-            return response.data.projects.filter(
-              project => project.sectionId === sectionId
-            );
-          }
-
-          return response.data.projects;
+        if (sectionId) {
+          return response.data.projects.filter(
+            project => project.sectionId === sectionId
+          );
         }
+
+        return response.data.projects;
       },
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Sections.js
+++ b/src/endpoints/Sections.js
@@ -7,17 +7,15 @@ export default class Sections extends Endpoint {
     descriptor: OrganizationDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Section[]>>(
-      {
-        api: async () => {
-          const response = await this.apiRequest(
-            `sections?organizationId=${descriptor.organizationId}`
-          );
+    return this.configureRequest<Promise<Section[]>>({
+      api: async () => {
+        const response = await this.apiRequest(
+          `sections?organizationId=${descriptor.organizationId}`
+        );
 
-          return response;
-        }
+        return response;
       },
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Shares.js
+++ b/src/endpoints/Shares.js
@@ -19,37 +19,33 @@ export default class Shares extends Endpoint {
     shareInput: ShareInput,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<T>>(
-      {
-        api: () => {
-          return this.apiRequest("share_links", {
-            method: "POST",
-            body: {
-              ...descriptor,
-              ...shareInput,
-              commitSha: (shareInput: any).sha
-            },
-            headers
-          });
-        }
+    return this.configureRequest<Promise<T>>({
+      api: () => {
+        return this.apiRequest("share_links", {
+          method: "POST",
+          body: {
+            ...descriptor,
+            ...shareInput,
+            commitSha: (shareInput: any).sha
+          },
+          headers
+        });
       },
       requestOptions
-    );
+    });
   }
 
   info<T: Share>(
     descriptor: ShareDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<T>>(
-      {
-        api: () => {
-          return this.apiRequest(`share_links/${inferShareId(descriptor)}`, {
-            headers
-          });
-        }
+    return this.configureRequest<Promise<T>>({
+      api: () => {
+        return this.apiRequest(`share_links/${inferShareId(descriptor)}`, {
+          headers
+        });
       },
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Users.js
+++ b/src/endpoints/Users.js
@@ -10,38 +10,34 @@ import Endpoint from "../endpoints/Endpoint";
 
 export default class Users extends Endpoint {
   info(descriptor: UserDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<User>>(
-      {
-        api: () => {
-          return this.apiRequest(`users/${descriptor.userId}`);
-        }
+    return this.configureRequest<Promise<User>>({
+      api: () => {
+        return this.apiRequest(`users/${descriptor.userId}`);
       },
       requestOptions
-    );
+    });
   }
 
   list(
     descriptor: OrganizationDescriptor | ProjectDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<User[]>>(
-      {
-        api: async () => {
-          let url = "";
+    return this.configureRequest<Promise<User[]>>({
+      api: async () => {
+        let url = "";
 
-          if (descriptor.organizationId) {
-            url = `organizations/${descriptor.organizationId}/memberships`;
-          }
-
-          if (descriptor.projectId) {
-            url = `projects/${descriptor.projectId}/memberships`;
-          }
-
-          const response = await this.apiRequest(url);
-          return response.data.map(membership => membership.user);
+        if (descriptor.organizationId) {
+          url = `organizations/${descriptor.organizationId}/memberships`;
         }
+
+        if (descriptor.projectId) {
+          url = `projects/${descriptor.projectId}/memberships`;
+        }
+
+        const response = await this.apiRequest(url);
+        return response.data.map(membership => membership.user);
       },
       requestOptions
-    );
+    });
   }
 }

--- a/src/endpoints/Webhooks.js
+++ b/src/endpoints/Webhooks.js
@@ -17,45 +17,39 @@ export default class Users extends Endpoint {
     descriptor: OrganizationDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Webhook[]>>(
-      {
-        api: () => {
-          return this.apiRequest(
-            `organizations/${descriptor.organizationId}/webhooks`
-          );
-        }
+    return this.configureRequest<Promise<Webhook[]>>({
+      api: () => {
+        return this.apiRequest(
+          `organizations/${descriptor.organizationId}/webhooks`
+        );
       },
       requestOptions
-    );
+    });
   }
 
   info(descriptor: WebhookDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Webhook>>(
-      {
-        api: () => {
-          return this.apiRequest(
-            `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}`
-          );
-        }
+    return this.configureRequest<Promise<Webhook>>({
+      api: () => {
+        return this.apiRequest(
+          `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}`
+        );
       },
       requestOptions
-    );
+    });
   }
 
   events(
     descriptor: OrganizationDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<WebhookEvent[]>>(
-      {
-        api: () => {
-          return this.apiRequest(
-            `organizations/${descriptor.organizationId}/webhooks/events`
-          );
-        }
+    return this.configureRequest<Promise<WebhookEvent[]>>({
+      api: () => {
+        return this.apiRequest(
+          `organizations/${descriptor.organizationId}/webhooks/events`
+        );
       },
       requestOptions
-    );
+    });
   }
 
   create(
@@ -63,22 +57,20 @@ export default class Users extends Endpoint {
     webhook: NewWebhook,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Webhook>>(
-      {
-        api: () => {
-          return this.apiRequest(
-            `organizations/${descriptor.organizationId}/webhooks/subscribe`,
-            {
-              method: "POST",
-              body: {
-                subscription: webhook
-              }
+    return this.configureRequest<Promise<Webhook>>({
+      api: () => {
+        return this.apiRequest(
+          `organizations/${descriptor.organizationId}/webhooks/subscribe`,
+          {
+            method: "POST",
+            body: {
+              subscription: webhook
             }
-          );
-        }
+          }
+        );
       },
       requestOptions
-    );
+    });
   }
 
   update(
@@ -86,83 +78,73 @@ export default class Users extends Endpoint {
     webhook: Webhook,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Webhook>>(
-      {
-        api: () => {
-          return this.apiRequest(
-            `organizations/${descriptor.organizationId}/webhooks/subscribe`,
-            {
-              method: "POST",
-              body: {
-                subscription: webhook
-              }
+    return this.configureRequest<Promise<Webhook>>({
+      api: () => {
+        return this.apiRequest(
+          `organizations/${descriptor.organizationId}/webhooks/subscribe`,
+          {
+            method: "POST",
+            body: {
+              subscription: webhook
             }
-          );
-        }
+          }
+        );
       },
       requestOptions
-    );
+    });
   }
 
   delete(descriptor: WebhookDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<void>>(
-      {
-        api: () => {
-          return this.apiRequest(
-            `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}/unsubscribe`,
-            { method: "DELETE" }
-          );
-        }
+    return this.configureRequest<Promise<void>>({
+      api: () => {
+        return this.apiRequest(
+          `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}/unsubscribe`,
+          { method: "DELETE" }
+        );
       },
       requestOptions
-    );
+    });
   }
 
   ping(descriptor: WebhookDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<void>>(
-      {
-        api: () => {
-          return this.apiRequest(
-            `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}/ping`,
-            { method: "POST" }
-          );
-        }
+    return this.configureRequest<Promise<void>>({
+      api: () => {
+        return this.apiRequest(
+          `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}/ping`,
+          { method: "POST" }
+        );
       },
       requestOptions
-    );
+    });
   }
 
   deliveries(
     descriptor: WebhookDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<WebhookDelivery[]>>(
-      {
-        api: () => {
-          return this.apiRequest(
-            `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}/deliveries`
-          );
-        }
+    return this.configureRequest<Promise<WebhookDelivery[]>>({
+      api: () => {
+        return this.apiRequest(
+          `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}/deliveries`
+        );
       },
       requestOptions
-    );
+    });
   }
 
   redeliver(
     descriptor: WebhookDeliveryDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<void>>(
-      {
-        api: () => {
-          return this.apiRequest(
-            `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}/deliveries/${descriptor.deliveryId}/redeliver`,
-            { method: "POST" }
-          );
-        }
+    return this.configureRequest<Promise<void>>({
+      api: () => {
+        return this.apiRequest(
+          `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}/deliveries/${descriptor.deliveryId}/redeliver`,
+          { method: "POST" }
+        );
       },
       requestOptions
-    );
+    });
   }
 
   verify(
@@ -171,14 +153,12 @@ export default class Users extends Endpoint {
     signingKey: string,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<boolean>>(
-      {
-        api: async () => {
-          const signature = sha256.hmac(signingKey, JSON.stringify(payload));
-          return signature === expectedSignature;
-        }
+    return this.configureRequest<Promise<boolean>>({
+      api: async () => {
+        const signature = sha256.hmac(signingKey, JSON.stringify(payload));
+        return signature === expectedSignature;
       },
       requestOptions
-    );
+    });
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -88,11 +88,6 @@ export type ErrorMap = {
   [mode: string]: Error
 };
 
-export type RequestConfig<T> = {
-  api?: () => T,
-  cli?: () => T
-};
-
 export type ApiRequestOptions = {
   customHostname?: string,
   raw?: boolean
@@ -100,6 +95,12 @@ export type ApiRequestOptions = {
 
 export type RequestOptions = {
   transportMode?: ("api" | "cli")[]
+};
+
+export type RequestConfig<T> = {
+  api?: () => T,
+  cli?: () => T,
+  requestOptions?: RequestOptions
 };
 
 export type ListOptions = {

--- a/tests/Client.test.js
+++ b/tests/Client.test.js
@@ -8,7 +8,8 @@ import {
   mockAPI,
   mockCLI,
   API_CLIENT,
-  CLIENT_CONFIG
+  CLIENT_CONFIG,
+  CLI_CLIENT
 } from "../src/util/testing";
 import type { AccessToken, RequestOptions } from "../src/types";
 
@@ -191,6 +192,33 @@ describe("Client", () => {
     expect(response).toEqual([
       {
         id: "org-id"
+      }
+    ]);
+  });
+
+  test("CursorPromise transportMode", async () => {
+    mockAPI("/activities?organizationId=org-id", {
+      data: {
+        activities: [
+          {
+            id: "activity-id"
+          }
+        ]
+      }
+    });
+
+    const response = await CLI_CLIENT.activities.list(
+      {
+        organizationId: "org-id"
+      },
+      {
+        transportMode: ["api"]
+      }
+    );
+
+    expect(response).toEqual([
+      {
+        id: "activity-id"
       }
     ]);
   });

--- a/tests/Client.test.js
+++ b/tests/Client.test.js
@@ -10,7 +10,7 @@ import {
   API_CLIENT,
   CLIENT_CONFIG
 } from "../src/util/testing";
-import type { AccessToken } from "../src/types";
+import type { AccessToken, RequestOptions } from "../src/types";
 
 const Client = require("../src/Client").default;
 
@@ -173,5 +173,25 @@ describe("Client", () => {
     expect((spawnSpy: any).mock.calls[0][1].includes("--user-token")).toBe(
       false
     );
+  });
+
+  test("undefined request options", async () => {
+    mockAPI("/organizations", {
+      data: [
+        {
+          id: "org-id"
+        }
+      ]
+    });
+
+    const response = await API_CLIENT.organizations.list(
+      ((null: any): RequestOptions)
+    );
+
+    expect(response).toEqual([
+      {
+        id: "org-id"
+      }
+    ]);
   });
 });


### PR DESCRIPTION
This pull request is a little housekeeping to consolidate the signature for `Endpoint#configureRequest`. Rather than pass in one argument for endpoint configuration and another for request configuration, everything is passed as one configuration object.

**Note:** Almost all of the changes in this PR are formatting from Prettier, so it's best to hide whitespace changes when viewing it. Flow also strongly types all of the actual code changes here, which should help the review.