### PR TITLE
chore(release): 8.0.0-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abstract-sdk",
-  "version": "7.0.1",
+  "version": "8.0.0-beta.0",
   "description": "Universal JavaScript bindings for the Abstract API and CLI",
   "keywords": [
     "abstract",


### PR DESCRIPTION
This pull request cuts `abstract-sdk@8.0.0-beta.0` which includes an update to changeset responses.