### PR TITLE
feat!: remove support for node 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
           "corejs": 2,
           "useBuiltIns": "usage",
           "targets": {
-            "node": 8
+            "node": 10
           },
           "exclude": [
             "transform-regenerator"


### PR DESCRIPTION
This pull request removes support for Node 8 since [its end of life date is 12/31/2019](https://nodejs.org/en/about/releases/). This means that asynchronous iteration support will no longer have to be down-emitted, which will fix the `core-js` issues reported in #186.

References #186 