### PR TITLE
chore(release): 8.0.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abstract-sdk",
-  "version": "8.0.0-beta.0",
+  "version": "8.0.0-beta.1",
   "description": "Universal JavaScript bindings for the Abstract API and CLI",
   "keywords": [
     "abstract",


### PR DESCRIPTION
This pull request cuts `abstract-sdk@8.0.0-beta.1` which removes Node 8 support and in turn fixes a reported `core-js` issue (#186).