### PR TITLE
chore(release): 8.0.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abstract-sdk",
-  "version": "8.0.0-beta.1",
+  "version": "8.0.0-beta.2",
   "description": "Universal JavaScript bindings for the Abstract API and CLI",
   "keywords": [
     "abstract",


### PR DESCRIPTION
This pull request cuts `abstract-sdk@8.0.0-beta.2` which adds a new `isNew` property to `Project`.