### PR TITLE
fix: Ensure policies are returned in branches payload

### DIFF
--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -9,14 +9,22 @@ import type {
 import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
+// Version 17 returns policies for branches
+const headers = {
+  "Abstract-Api-Version": "17"
+};
+
 export default class Branches extends Endpoint {
   info(descriptor: BranchDescriptor, requestOptions: RequestOptions = {}) {
     return this.configureRequest<Promise<Branch>>({
       api: async () => {
         const response = await this.apiRequest(
-          `projects/${descriptor.projectId}/branches/${descriptor.branchId}`
+          `projects/${descriptor.projectId}/branches/${descriptor.branchId}`,
+          {
+            headers
+          }
         );
-        return wrap(response);
+        return wrap(response.data, response);
       },
 
       cli: async () => {
@@ -47,7 +55,10 @@ export default class Branches extends Endpoint {
         const query = querystring.stringify({ filter });
 
         const response = await this.apiRequest(
-          `projects/${descriptor.projectId}/branches/?${query}`
+          `projects/${descriptor.projectId}/branches/?${query}`,
+          {
+            headers
+          }
         );
 
         return wrap(response.data.branches, response);

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -27,10 +27,10 @@ export default class Commits extends Endpoint {
         // loading commits with a share token requires a branchId so this
         // route is maintained for that circumstance
         const response = descriptor.branchId
-          ? this.apiRequest(
+          ? await this.apiRequest(
               `projects/${descriptor.projectId}/branches/${descriptor.branchId}/commits/${descriptor.sha}`
             )
-          : this.apiRequest(
+          : await this.apiRequest(
               `projects/${descriptor.projectId}/commits/${descriptor.sha}`
             );
         return wrap(response);

--- a/tests/Client.test.js
+++ b/tests/Client.test.js
@@ -249,11 +249,11 @@ describe("Client", () => {
       id: "branch-id"
     };
 
-    mockAPI("/projects/project-id/branches/branch-id", rawResponse);
+    mockAPI("/projects/project-id/commits/123", rawResponse);
 
-    const response = await API_CLIENT.branches.info({
-      branchId: "branch-id",
-      projectId: "project-id"
+    const response = await API_CLIENT.commits.info({
+      projectId: "project-id",
+      sha: "123"
     });
 
     expect(API_CLIENT.unwrap(response)).toEqual(rawResponse);
@@ -266,11 +266,11 @@ describe("Client", () => {
       }
     ];
 
-    mockAPI("/projects/project-id/branches/branch-id", rawResponse);
+    mockAPI("/projects/project-id/commits/123", rawResponse);
 
-    const response = await API_CLIENT.branches.info({
-      branchId: "branch-id",
-      projectId: "project-id"
+    const response = await API_CLIENT.commits.info({
+      projectId: "project-id",
+      sha: "123"
     });
 
     expect(API_CLIENT.unwrap(response)).toEqual(rawResponse);

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -10,7 +10,9 @@ describe("branches", () => {
   describe("info", () => {
     test("api", async () => {
       mockAPI("/projects/project-id/branches/branch-id", {
-        id: "branch-id"
+        data: {
+          id: "branch-id"
+        }
       });
 
       const response = await API_CLIENT.branches.info({


### PR DESCRIPTION
fix: Commits list api endpoint (broken in v8 prerelease)
fix: Ensure policies are returned in unwrapped branches payload