### PR TITLE
feat: support branch searching

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -149,8 +149,8 @@ interface Assets extends Endpoint {
 interface Branches extends Endpoint {
   info(descriptor: BranchDescriptor, requestOptions: RequestOptions): Promise<Branch>;
   list(
-    descriptor: ProjectDescriptor,
-    options?: RequestOptions & { filter?: "active" | "archived" | "mine" }
+    descriptor?: ProjectDescriptor,
+    options?: RequestOptions & { filter?: "active" | "archived" | "mine", search?: string }
   ): Promise<Branch[]>;
 }
 

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -214,7 +214,7 @@ to be created for logical chunks of work – for example designing a new feature
 
 ![CLI][cli-icon] ![API][api-icon]
 
-`branches.list(ProjectDescriptor, { ...RequestOptions, filter?: "active" | "archived" | "mine" }): Promise<Branch[]>`
+`branches.list(ProjectDescriptor, { ...RequestOptions, filter?: "active" | "archived" | "mine", search?: string }): Promise<Branch[]>`
 
 List the active branches for a project
 
@@ -225,6 +225,16 @@ abstract.branches.list({
   filter: "active"
 });
 ```
+
+Search for a branch by name across all projects 
+
+```js
+abstract.branches.list(undefined, {
+  search: "branch name"
+});
+```
+
+> Note: Searching for branches is only available when using the [API transport](/docs/transports).
 
 ### Retrieve a branch
 

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -26,13 +26,10 @@ export default class Commits extends Endpoint {
       api: async () => {
         // loading commits with a share token requires a branchId so this
         // route is maintained for that circumstance
-        const response = descriptor.branchId
-          ? await this.apiRequest(
-              `projects/${descriptor.projectId}/branches/${descriptor.branchId}/commits/${descriptor.sha}`
-            )
-          : await this.apiRequest(
-              `projects/${descriptor.projectId}/commits/${descriptor.sha}`
-            );
+        const requestUrl = descriptor.branchId
+          ? `projects/${descriptor.projectId}/branches/${descriptor.branchId}/commits/${descriptor.sha}`
+          : `projects/${descriptor.projectId}/commits/${descriptor.sha}`;
+        const response = await this.apiRequest(requestUrl);
         return wrap(response);
       },
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -30,6 +30,14 @@ export class FileAPIError extends BaseError {
   }
 }
 
+export class BranchSearchCLIError extends BaseError {
+  constructor() {
+    super(
+      "This method requires a ProjectDescriptor when using the CLI transport."
+    );
+  }
+}
+
 export class EndpointUndefinedError extends BaseError {
   constructor(transport: string) {
     super(`Endpoint not defined in ${transport} transport.`);

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -5,6 +5,7 @@ import {
   API_CLIENT,
   CLI_CLIENT
 } from "../../src/util/testing";
+import { BranchSearchCLIError } from "../../src/errors";
 
 describe("branches", () => {
   describe("info", () => {
@@ -91,6 +92,28 @@ describe("branches", () => {
       ]);
     });
 
+    test("api - list", async () => {
+      mockAPI("/branches/?search=foo", {
+        data: {
+          branches: [
+            {
+              id: "branch-id"
+            }
+          ]
+        }
+      });
+
+      const response = await API_CLIENT.branches.list(undefined, {
+        search: "foo"
+      });
+
+      expect(response).toEqual([
+        {
+          id: "branch-id"
+        }
+      ]);
+    });
+
     test("cli", async () => {
       mockCLI(["branches", "project-id"], {
         branches: [
@@ -134,6 +157,14 @@ describe("branches", () => {
           id: "branch-id"
         }
       ]);
+    });
+
+    test("cli - no descriptor", async () => {
+      try {
+        await CLI_CLIENT.branches.list(undefined);
+      } catch (error) {
+        expect(error.errors.cli).toBeInstanceOf(BranchSearchCLIError);
+      }
     });
   });
 });


### PR DESCRIPTION
This pull request updates the `branches.list` endpoint to support name-based searches when using the API transport.

References #202 
Requires https://github.com/goabstract/projects/pull/3891 