### PR TITLE
feat: add layer dependency filtering options

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -240,11 +240,16 @@ interface Files extends Endpoint {
   raw(descriptor: FileDescriptor, options?: RawOptions): Promise<void>;
 }
 
+type LayersListOptions = ListOptions & {
+  excludeLibraryDependencies?: boolean,
+  onlyLibraryDependencies?: boolean,
+}
+
 interface Layers extends Endpoint {
   info(descriptor: LayerVersionDescriptor, requestOptions: RequestOptions): Promise<Layer>;
   list(
     descriptor: FileDescriptor | PageDescriptor,
-    options?: ListOptions
+    options?: LayersListOptions
   ): Promise<Layer[]>;
 }
 

--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -241,8 +241,7 @@ interface Files extends Endpoint {
 }
 
 type LayersListOptions = ListOptions & {
-  excludeLibraryDependencies?: boolean,
-  onlyLibraryDependencies?: boolean,
+  fromLibraries: "include" | "exclude" | "only"
 }
 
 interface Layers extends Endpoint {

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -851,7 +851,7 @@ A layer is a container for designs. In Sketch a layer usually represents an artb
 
 ![CLI][cli-icon] ![API][api-icon]
 
-`layers.list(FileDescriptor | PageDescriptor, ListOptions): Promise<Layer[]>`
+`layers.list(FileDescriptor | PageDescriptor, LayersListOptions): Promise<Layer[]>`
 
 List the layers for a file at a commit
 
@@ -875,7 +875,9 @@ abstract.layers.list({
   sha: "fb7e9b50da6c330fc43ffb369616f0cd1fa92cc2"
 }, {
   limit: 25,
-  offset: 0
+  offset: 0,
+  excludeLibraryDependencies: false,
+  onlyLibraryDependencies: false
 });
 ```
 

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -875,9 +875,23 @@ abstract.layers.list({
   sha: "fb7e9b50da6c330fc43ffb369616f0cd1fa92cc2"
 }, {
   limit: 25,
+  offset: 0
+});
+```
+
+A file can also contain layers from external libraries. If you'd like to only see the layers in this file and not the external library elements they depend upon, use the `fromLibraries` option…
+
+```js
+abstract.layers.list({
+  projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78",
+  branchId: "master",
+  fileId: "51DE7CD1-ECDC-473C-B30E-62AE913743B7",
+  pageId: "7D2D2599-9B3F-49BC-9F86-9D9D532F143A",
+  sha: "fb7e9b50da6c330fc43ffb369616f0cd1fa92cc2"
+}, {
+  limit: 25,
   offset: 0,
-  excludeLibraryDependencies: false,
-  onlyLibraryDependencies: false
+  fromLibraries: "exclude"
 });
 ```
 
@@ -1626,6 +1640,16 @@ Options objects that can be passed to different SDK endpoints.
   transportMode?: ("api" | "cli")[],
   limit?: number,
   offset?: number
+}
+```
+
+### LayersListOptions
+```js
+{
+  transportMode?: ("api" | "cli")[],
+  limit?: number,
+  offset?: number
+  fromLibraries?: "include" | "exclude" | "only" # default is "include"
 }
 ```
 

--- a/src/endpoints/Layers.js
+++ b/src/endpoints/Layers.js
@@ -11,6 +11,12 @@ import type {
 import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
+type LayersListOptions = {
+  ...ListOptions,
+  excludeLibraryDependencies?: boolean,
+  onlyLibraryDependencies?: boolean
+};
+
 export default class Layers extends Endpoint {
   async info(
     descriptor: LayerVersionDescriptor,
@@ -48,9 +54,15 @@ export default class Layers extends Endpoint {
 
   async list(
     descriptor: FileDescriptor | PageDescriptor,
-    options: ListOptions = {}
+    options: LayersListOptions = {}
   ) {
-    const { limit, offset, ...requestOptions } = options;
+    const {
+      limit,
+      offset,
+      excludeLibraryDependencies,
+      onlyLibraryDependencies,
+      ...requestOptions
+    } = options;
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );
@@ -58,9 +70,10 @@ export default class Layers extends Endpoint {
     return this.configureRequest<Promise<Layer[]>>({
       api: async () => {
         const query = querystring.stringify({
-          ...latestDescriptor,
           limit,
-          offset
+          offset,
+          excludeLibraryDependencies,
+          onlyLibraryDependencies
         });
 
         const response = await this.apiRequest(

--- a/src/endpoints/Layers.js
+++ b/src/endpoints/Layers.js
@@ -13,7 +13,7 @@ import { wrap } from "../util/helpers";
 
 type LayersListOptions = {
   ...ListOptions,
-  fromLibraries?: "include" | "excluce" | "only"
+  fromLibraries?: "include" | "exclude" | "only"
 };
 
 export default class Layers extends Endpoint {

--- a/src/endpoints/Layers.js
+++ b/src/endpoints/Layers.js
@@ -13,8 +13,7 @@ import { wrap } from "../util/helpers";
 
 type LayersListOptions = {
   ...ListOptions,
-  excludeLibraryDependencies?: boolean,
-  onlyLibraryDependencies?: boolean
+  fromLibraries?: "include" | "excluce" | "only"
 };
 
 export default class Layers extends Endpoint {
@@ -56,13 +55,7 @@ export default class Layers extends Endpoint {
     descriptor: FileDescriptor | PageDescriptor,
     options: LayersListOptions = {}
   ) {
-    const {
-      limit,
-      offset,
-      excludeLibraryDependencies,
-      onlyLibraryDependencies,
-      ...requestOptions
-    } = options;
+    const { limit, offset, fromLibraries, ...requestOptions } = options;
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );
@@ -70,10 +63,10 @@ export default class Layers extends Endpoint {
     return this.configureRequest<Promise<Layer[]>>({
       api: async () => {
         const query = querystring.stringify({
+          ...latestDescriptor,
           limit,
           offset,
-          excludeLibraryDependencies,
-          onlyLibraryDependencies
+          fromLibraries
         });
 
         const response = await this.apiRequest(

--- a/tests/endpoints/Layers.test.js
+++ b/tests/endpoints/Layers.test.js
@@ -54,16 +54,13 @@ describe("layers", () => {
 
   describe("list", () => {
     test("api", async () => {
-      mockAPI(
-        "/projects/project-id/branches/branch-id/files/file-id/layers?branchId=branch-id&fileId=file-id&projectId=project-id&sha=sha",
-        {
-          layers: [
-            {
-              id: "layer-id"
-            }
-          ]
-        }
-      );
+      mockAPI("/projects/project-id/branches/branch-id/files/file-id/layers?", {
+        layers: [
+          {
+            id: "layer-id"
+          }
+        ]
+      });
 
       const response = await API_CLIENT.layers.list({
         branchId: "branch-id",

--- a/tests/endpoints/Layers.test.js
+++ b/tests/endpoints/Layers.test.js
@@ -54,13 +54,16 @@ describe("layers", () => {
 
   describe("list", () => {
     test("api", async () => {
-      mockAPI("/projects/project-id/branches/branch-id/files/file-id/layers?", {
-        layers: [
-          {
-            id: "layer-id"
-          }
-        ]
-      });
+      mockAPI(
+        "/projects/project-id/branches/branch-id/files/file-id/layers?branchId=branch-id&fileId=file-id&projectId=project-id&sha=sha",
+        {
+          layers: [
+            {
+              id: "layer-id"
+            }
+          ]
+        }
+      );
 
       const response = await API_CLIENT.layers.list({
         branchId: "branch-id",


### PR DESCRIPTION
Depends on https://github.com/goabstract/projects/pull/3894, posting the same explanation here for visibility

This adds two new filtering options for layers:

- `excludeLibraryDependencies` - this will make it so that symbols from external libraries are not included in the list of layers. These are the items that we show as "dependencies" in the file list and aren't shown by default unless you click on them.
- `onlyLibraryDependencies` - the opposite of `excludeLibraryDependencies`. You can choose this option if you need to load the library dependencies separately.

These options should help our pagination of layers be a little more intuitive so that we don't load pages of data that aren't even shown in the screen you're looking at.