### PR TITLE
fix: pass branch id to cli for data endpoint

### DIFF
--- a/src/endpoints/Data.js
+++ b/src/endpoints/Data.js
@@ -29,6 +29,7 @@ export default class Data extends Endpoint {
           "layer",
           "data",
           latestDescriptor.projectId,
+          latestDescriptor.branchId,
           latestDescriptor.sha,
           latestDescriptor.fileId,
           latestDescriptor.layerId

--- a/tests/endpoints/Data.test.js
+++ b/tests/endpoints/Data.test.js
@@ -30,9 +30,20 @@ describe("data", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["layer", "data", "project-id", "sha", "file-id", "layer-id"], {
-        layerId: "layer-id"
-      });
+      mockCLI(
+        [
+          "layer",
+          "data",
+          "project-id",
+          "branch-id",
+          "sha",
+          "file-id",
+          "layer-id"
+        ],
+        {
+          layerId: "layer-id"
+        }
+      );
 
       const response = await CLI_CLIENT.data.info({
         branchId: "branch-id",


### PR DESCRIPTION
When using the cli transport for layer data, the following error is getting bubbled up from `abstract-sdk`:

> Error runtime error: index out of range [4] with length 4 ### CLI command: abstract-cli layer data [projectId] [sha] [fileId] [layerId]

We aren't currently passing in a branch id, even though the version of abstract-cli we depend upon uses it.