### PR TITLE
feat: add layer filtering options to cli transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.3.4",
-    "@elasticprojects/abstract-cli": "^2.3.0",
+    "@elasticprojects/abstract-cli": "^3.5.0",
     "cross-fetch": "^3.0.1",
     "debug": "^4.0.1",
     "flow-typed": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abstract-sdk",
-  "version": "8.0.0-beta.7",
+  "version": "8.0.0-beta.9",
   "description": "Universal JavaScript bindings for the Abstract API and CLI",
   "keywords": [
     "abstract",

--- a/src/endpoints/Layers.js
+++ b/src/endpoints/Layers.js
@@ -77,13 +77,30 @@ export default class Layers extends Endpoint {
       },
 
       cli: async () => {
-        const response = await this.cliRequest([
+        const args = [
           "layers",
           latestDescriptor.projectId,
           latestDescriptor.sha,
           latestDescriptor.fileId
-        ]);
+        ];
 
+        if (limit) {
+          args.push(`--limit=${limit}`);
+        }
+
+        if (offset) {
+          args.push(`--offset=${offset}`);
+        }
+
+        if (latestDescriptor.pageId) {
+          args.push(`--page-id=${latestDescriptor.pageId}`);
+        }
+
+        if (fromLibraries) {
+          args.push(`--from-libraries=${fromLibraries}`);
+        }
+
+        const response = await this.cliRequest(args);
         return wrap(response.layers, response);
       },
 

--- a/tests/endpoints/Layers.test.js
+++ b/tests/endpoints/Layers.test.js
@@ -101,5 +101,48 @@ describe("layers", () => {
         }
       ]);
     });
+
+    test("cli with options", async () => {
+      mockCLI(
+        [
+          "layers",
+          "project-id",
+          "sha",
+          "file-id",
+          "--limit=1",
+          "--offset=1",
+          "--page-id=page-id",
+          "--from-libraries=include"
+        ],
+        {
+          layers: [
+            {
+              id: "layer-id"
+            }
+          ]
+        }
+      );
+
+      const response = await CLI_CLIENT.layers.list(
+        {
+          projectId: "project-id",
+          branchId: "branch-id",
+          sha: "sha",
+          fileId: "file-id",
+          pageId: "page-id"
+        },
+        {
+          limit: 1,
+          offset: 1,
+          fromLibraries: "include"
+        }
+      );
+
+      expect(response).toEqual([
+        {
+          id: "layer-id"
+        }
+      ]);
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -721,10 +721,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@elasticprojects/abstract-cli@^2.3.0":
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/@elasticprojects/abstract-cli/-/abstract-cli-2.20.0.tgz#f1a4d192ccd9f1a8ca843266eee13ba1d4e71ecb"
-  integrity sha512-ehYhpkBIqbfdCxHej21xUxCbfjh5xtzQG0YXXkundXcS+aKp+5ANNqv439zn+9a3d+hcKwws204JADioFbuJlQ==
+"@elasticprojects/abstract-cli@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@elasticprojects/abstract-cli/-/abstract-cli-3.5.0.tgz#d0b28a2eda039720243425d5207bbb49da90d6ab"
+  integrity sha512-U+gYbvYkpRY5pQlFJTizQItO39O7elwbcQiYEOXb8cp5fUwsOxiEtBJipCmsBz12aWan6xvgfeMtQw5x1J/tLA==
 
 "@elasticprojects/eslint-config-abstract@^4.1.0":
   version "4.1.0"


### PR DESCRIPTION
Depends on https://github.com/goabstract/projects/pull/3929 and a new version of abstract-cli being released

This PR adds filtering options to `layers.list` for the `cli` transport so that that same filtering options are available as the `api` transport. Previously, sdk would allow you to pass filtering options but would ignore them for the `cli` transport.

Documentation should already be up-to-date since we already support these options for the `api` transport.