### PR TITLE
refactor: stop using deprecated CLI commands

### DIFF
--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -30,10 +30,10 @@ export default class Branches extends Endpoint {
 
       cli: async () => {
         const response = await this.cliRequest([
-          "branch",
-          "load",
-          descriptor.projectId,
-          descriptor.branchId
+          "branches",
+          "get",
+          descriptor.branchId,
+          ...["--project-id", descriptor.projectId]
         ]);
         return wrap(response);
       },
@@ -69,7 +69,8 @@ export default class Branches extends Endpoint {
         }
         const response = await this.cliRequest([
           "branches",
-          descriptor.projectId,
+          "list",
+          ...["--project-id", descriptor.projectId],
           ...(filter ? ["--filter", filter] : [])
         ]);
 

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -33,7 +33,7 @@ export default class Branches extends Endpoint {
           "branches",
           "get",
           descriptor.branchId,
-          ...["--project-id", descriptor.projectId]
+          `--project-id=${descriptor.projectId}`
         ]);
         return wrap(response);
       },
@@ -70,7 +70,7 @@ export default class Branches extends Endpoint {
         const response = await this.cliRequest([
           "branches",
           "list",
-          ...["--project-id", descriptor.projectId],
+          `--project-id=${descriptor.projectId}`,
           ...(filter ? ["--filter", filter] : [])
         ]);
 

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -38,7 +38,7 @@ export default class Commits extends Endpoint {
           "commits",
           "get",
           descriptor.sha,
-          ...["--project-id", descriptor.projectId]
+          `--project-id=${descriptor.projectId}`
         ]);
 
         return wrap(response.commit, response);
@@ -80,8 +80,8 @@ export default class Commits extends Endpoint {
         const response = await this.cliRequest([
           "commits",
           "list",
-          ...["--project-id", descriptor.projectId],
-          ...["--branch-id", descriptor.branchId],
+          `--project-id=${descriptor.projectId}`,
+          `--branch-id=${descriptor.branchId}`,
           ...(descriptor.fileId ? ["--file-id", descriptor.fileId] : []),
           ...(descriptor.layerId ? ["--layer-id", descriptor.layerId] : []),
           ...(options.startSha ? ["--start-sha", options.startSha] : []),

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -35,9 +35,10 @@ export default class Commits extends Endpoint {
 
       cli: async () => {
         const response = await this.cliRequest([
-          "commit",
-          descriptor.projectId,
-          descriptor.sha
+          "commits",
+          "get",
+          descriptor.sha,
+          ...["--project-id", descriptor.projectId]
         ]);
 
         return wrap(response.commit, response);
@@ -78,8 +79,9 @@ export default class Commits extends Endpoint {
       cli: async () => {
         const response = await this.cliRequest([
           "commits",
-          descriptor.projectId,
-          descriptor.branchId,
+          "list",
+          ...["--project-id", descriptor.projectId],
+          ...["--branch-id", descriptor.branchId],
           ...(descriptor.fileId ? ["--file-id", descriptor.fileId] : []),
           ...(descriptor.layerId ? ["--layer-id", descriptor.layerId] : []),
           ...(options.startSha ? ["--start-sha", options.startSha] : []),

--- a/src/endpoints/Files.js
+++ b/src/endpoints/Files.js
@@ -36,8 +36,8 @@ export default class Files extends Endpoint {
           "files",
           "meta",
           latestDescriptor.fileId,
-          ...["--project-id", latestDescriptor.projectId],
-          ...["--sha", latestDescriptor.sha]
+          `--project-id=${latestDescriptor.projectId}`,
+          `--sha=${latestDescriptor.sha}`
         ]);
 
         return wrap(response.file, response);
@@ -68,8 +68,8 @@ export default class Files extends Endpoint {
         const response = await this.cliRequest([
           "files",
           "list",
-          ...["--project-id", latestDescriptor.projectId],
-          ...["--sha", latestDescriptor.sha]
+          `--project-id=${latestDescriptor.projectId}`,
+          `--sha=${latestDescriptor.sha}`
         ]);
 
         return wrap(response.files, response);

--- a/src/endpoints/Files.js
+++ b/src/endpoints/Files.js
@@ -33,10 +33,11 @@ export default class Files extends Endpoint {
 
       cli: async () => {
         const response = await this.cliRequest([
-          "file",
-          latestDescriptor.projectId,
-          latestDescriptor.sha,
-          latestDescriptor.fileId
+          "files",
+          "meta",
+          latestDescriptor.fileId,
+          ...["--project-id", latestDescriptor.projectId],
+          ...["--sha", latestDescriptor.sha]
         ]);
 
         return wrap(response.file, response);
@@ -66,8 +67,9 @@ export default class Files extends Endpoint {
       cli: async () => {
         const response = await this.cliRequest([
           "files",
-          latestDescriptor.projectId,
-          latestDescriptor.sha
+          "list",
+          ...["--project-id", latestDescriptor.projectId],
+          ...["--sha", latestDescriptor.sha]
         ]);
 
         return wrap(response.files, response);
@@ -153,7 +155,7 @@ export default class Files extends Endpoint {
         }
 
         await this.cliRequest([
-          "file",
+          "files",
           "export",
           latestDescriptor.fileId,
           filename || process.cwd(),

--- a/tests/Client.test.js
+++ b/tests/Client.test.js
@@ -44,7 +44,7 @@ describe("Client", () => {
   test("all transports throw", async () => {
     mockAPI("/projects/project-id/branches/?", { ok: false }, 404);
 
-    mockCLI(["branches", "project-id"], undefined, {
+    mockCLI(["branches", "list", "--project-id", "project-id"], undefined, {
       code: "not_found"
     });
 
@@ -80,7 +80,7 @@ describe("Client", () => {
       }
     });
 
-    mockCLI(["branches", "project-id"], undefined, {
+    mockCLI(["branches", "list", "--project-id", "project-id"], undefined, {
       code: "not_found"
     });
 
@@ -148,13 +148,16 @@ describe("Client", () => {
       accessToken: (() => ({ shareId: "share-id" }): () => AccessToken)
     });
 
-    const spawnSpy = mockCLI(["branches", "project-id"], {
-      branches: [
-        {
-          id: "branch-id"
-        }
-      ]
-    });
+    const spawnSpy = mockCLI(
+      ["branches", "list", "--project-id", "project-id"],
+      {
+        branches: [
+          {
+            id: "branch-id"
+          }
+        ]
+      }
+    );
 
     const response = await client.branches.list(
       {

--- a/tests/Client.test.js
+++ b/tests/Client.test.js
@@ -44,7 +44,7 @@ describe("Client", () => {
   test("all transports throw", async () => {
     mockAPI("/projects/project-id/branches/?", { ok: false }, 404);
 
-    mockCLI(["branches", "list", "--project-id", "project-id"], undefined, {
+    mockCLI(["branches", "list", "--project-id=project-id"], undefined, {
       code: "not_found"
     });
 
@@ -80,7 +80,7 @@ describe("Client", () => {
       }
     });
 
-    mockCLI(["branches", "list", "--project-id", "project-id"], undefined, {
+    mockCLI(["branches", "list", "--project-id=project-id"], undefined, {
       code: "not_found"
     });
 
@@ -148,16 +148,13 @@ describe("Client", () => {
       accessToken: (() => ({ shareId: "share-id" }): () => AccessToken)
     });
 
-    const spawnSpy = mockCLI(
-      ["branches", "list", "--project-id", "project-id"],
-      {
-        branches: [
-          {
-            id: "branch-id"
-          }
-        ]
-      }
-    );
+    const spawnSpy = mockCLI(["branches", "list", "--project-id=project-id"], {
+      branches: [
+        {
+          id: "branch-id"
+        }
+      ]
+    });
 
     const response = await client.branches.list(
       {

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -27,7 +27,7 @@ describe("branches", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["branches", "get", "branch-id", "--project-id", "project-id"], {
+      mockCLI(["branches", "get", "branch-id", "--project-id=project-id"], {
         id: "branch-id"
       });
 
@@ -115,7 +115,7 @@ describe("branches", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["branches", "list", "--project-id", "project-id"], {
+      mockCLI(["branches", "list", "--project-id=project-id"], {
         branches: [
           {
             id: "branch-id"
@@ -136,7 +136,7 @@ describe("branches", () => {
 
     test("cli - filter", async () => {
       mockCLI(
-        ["branches", "list", "--project-id", "project-id", "--filter", "mine"],
+        ["branches", "list", "--project-id=project-id", "--filter", "mine"],
         {
           branches: [
             {

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -27,7 +27,7 @@ describe("branches", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["branch", "load", "project-id", "branch-id"], {
+      mockCLI(["branches", "get", "branch-id", "--project-id", "project-id"], {
         id: "branch-id"
       });
 
@@ -115,7 +115,7 @@ describe("branches", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["branches", "project-id"], {
+      mockCLI(["branches", "list", "--project-id", "project-id"], {
         branches: [
           {
             id: "branch-id"
@@ -135,13 +135,16 @@ describe("branches", () => {
     });
 
     test("cli - filter", async () => {
-      mockCLI(["branches", "project-id", "--filter", "mine"], {
-        branches: [
-          {
-            id: "branch-id"
-          }
-        ]
-      });
+      mockCLI(
+        ["branches", "list", "--project-id", "project-id", "--filter", "mine"],
+        {
+          branches: [
+            {
+              id: "branch-id"
+            }
+          ]
+        }
+      );
 
       const response = await CLI_CLIENT.branches.list(
         {

--- a/tests/endpoints/Commits.test.js
+++ b/tests/endpoints/Commits.test.js
@@ -40,7 +40,7 @@ describe("commits", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["commit", "project-id", "sha"], {
+      mockCLI(["commits", "get", "sha", "--project-id", "project-id"], {
         commit: {
           id: "commit-id"
         }
@@ -85,9 +85,19 @@ describe("commits", () => {
     });
 
     test("cli - without options", async () => {
-      mockCLI(["commits", "project-id", "branch-id"], {
-        commits: []
-      });
+      mockCLI(
+        [
+          "commits",
+          "list",
+          "--project-id",
+          "project-id",
+          "--branch-id",
+          "branch-id"
+        ],
+        {
+          commits: []
+        }
+      );
 
       const response = await CLI_CLIENT.commits.list({
         projectId: "project-id",
@@ -101,7 +111,10 @@ describe("commits", () => {
       mockCLI(
         [
           "commits",
+          "list",
+          "--project-id",
           "project-id",
+          "--branch-id",
           "branch-id",
           "--file-id",
           "file-id",

--- a/tests/endpoints/Commits.test.js
+++ b/tests/endpoints/Commits.test.js
@@ -40,7 +40,7 @@ describe("commits", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["commits", "get", "sha", "--project-id", "project-id"], {
+      mockCLI(["commits", "get", "sha", "--project-id=project-id"], {
         commit: {
           id: "commit-id"
         }
@@ -86,14 +86,7 @@ describe("commits", () => {
 
     test("cli - without options", async () => {
       mockCLI(
-        [
-          "commits",
-          "list",
-          "--project-id",
-          "project-id",
-          "--branch-id",
-          "branch-id"
-        ],
+        ["commits", "list", "--project-id=project-id", "--branch-id=branch-id"],
         {
           commits: []
         }
@@ -112,10 +105,8 @@ describe("commits", () => {
         [
           "commits",
           "list",
-          "--project-id",
-          "project-id",
-          "--branch-id",
-          "branch-id",
+          "--project-id=project-id",
+          "--branch-id=branch-id",
           "--file-id",
           "file-id",
           "--layer-id",

--- a/tests/endpoints/Files.test.js
+++ b/tests/endpoints/Files.test.js
@@ -54,15 +54,7 @@ describe("files", () => {
 
     test("cli", async () => {
       mockCLI(
-        [
-          "files",
-          "meta",
-          "file-id",
-          "--project-id",
-          "project-id",
-          "--sha",
-          "sha"
-        ],
+        ["files", "meta", "file-id", "--project-id=project-id", "--sha=sha"],
         {
           file: {
             id: "file-id"
@@ -107,7 +99,7 @@ describe("files", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["files", "list", "--project-id", "project-id", "--sha", "sha"], {
+      mockCLI(["files", "list", "--project-id=project-id", "--sha=sha"], {
         files: [
           {
             id: "file-id"

--- a/tests/endpoints/Files.test.js
+++ b/tests/endpoints/Files.test.js
@@ -53,11 +53,22 @@ describe("files", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["file", "project-id", "sha", "file-id"], {
-        file: {
-          id: "file-id"
+      mockCLI(
+        [
+          "files",
+          "meta",
+          "file-id",
+          "--project-id",
+          "project-id",
+          "--sha",
+          "sha"
+        ],
+        {
+          file: {
+            id: "file-id"
+          }
         }
-      });
+      );
 
       const response = await CLI_CLIENT.files.info({
         branchId: "branch-id",
@@ -96,7 +107,7 @@ describe("files", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["files", "project-id", "sha"], {
+      mockCLI(["files", "list", "--project-id", "project-id", "--sha", "sha"], {
         files: [
           {
             id: "file-id"
@@ -225,7 +236,7 @@ describe("files", () => {
     test("cli - exports file", async () => {
       mockCLI(
         [
-          "file",
+          "files",
           "export",
           "file-id",
           "filename",
@@ -256,7 +267,7 @@ describe("files", () => {
     test("cli - uses cwd", async () => {
       mockCLI(
         [
-          "file",
+          "files",
           "export",
           "file-id",
           "cwd",


### PR DESCRIPTION
Fairly straightforward PR. We deprecated a certain amount of commands in the CLI those last 6 to 12 months, this PR makes sure we're no longer using them.