### PR TITLE
fix: Allow abstract.com domain for share links and expose inferShareId

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 /* istanbul ignore file */
 import Client from "./Client";
+import { inferShareId } from "./util/helpers";
 import { paginate } from "./paginate";
 import * as sketch from "./sketch";
 import {
@@ -31,6 +32,7 @@ export {
   ServiceUnavailableError,
   UnauthorizedError,
   // Utilities
+  inferShareId,
   paginate,
   sketch
 };

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -2,7 +2,7 @@
 import type { ShareDescriptor } from "../types";
 
 function parseShareURL(url: string): ?string {
-  return url.split("share.goabstract.com/")[1];
+  return url.split(/share\.(?:go)?abstract\.com\//)[1];
 }
 
 export function inferShareId(shareDescriptor: ShareDescriptor): string {

--- a/tests/util/helpers.test.js
+++ b/tests/util/helpers.test.js
@@ -9,6 +9,11 @@ describe("helpers", () => {
         url: "share.goabstract.com/share-id"
       })
     ).toBe("share-id");
+    expect(
+      utils.inferShareId({
+        url: "share.abstract.com/share-id-2"
+      })
+    ).toBe("share-id-2");
   });
 
   test("inferShareId throws", () => {


### PR DESCRIPTION
Share links with the abstract.com domain should be considered valid. This PR updates the `parseShareURL` function to allow this domain.

I made a similar update in https://github.com/amccloud/storybook-addons-abstract/pull/6. In that PR, @amccloud [made the suggestion](https://github.com/amccloud/storybook-addons-abstract/pull/6#discussion_r372511342) that we expose `inferShareId` since he manually copied it into the package, so I've also done that in this PR 🙂
