### PR TITLE
chore: add custom api version to collections request

### DIFF
--- a/src/endpoints/Collections.js
+++ b/src/endpoints/Collections.js
@@ -14,9 +14,7 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 // Version 16 returns cached thumbnails
-const headers = {
-  "Abstract-Api-Version": "16"
-};
+const API_VERSION = 16;
 
 export default class Collections extends Endpoint {
   create(
@@ -54,13 +52,11 @@ export default class Collections extends Endpoint {
         const query = querystring.stringify({ layersPerCollection });
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}/collections/${descriptor.collectionId}?${query}`,
-          requestOptions._version
-            ? {
-                headers: {
-                  "Abstract-Api-Version": requestOptions._version
-                }
-              }
-            : { headers }
+          {
+            headers: {
+              "Abstract-Api-Version": requestOptions._version || API_VERSION
+            }
+          }
         );
         return wrap(response.data.collections[0], response);
       },
@@ -112,13 +108,11 @@ export default class Collections extends Endpoint {
 
         const response = await this.apiRequest(
           `projects/${projectId}/collections?${query}`,
-          requestOptions._version
-            ? {
-                headers: {
-                  "Abstract-Api-Version": requestOptions._version
-                }
-              }
-            : { headers }
+          {
+            headers: {
+              "Abstract-Api-Version": requestOptions._version || API_VERSION
+            }
+          }
         );
 
         return wrap(response.data.collections, response);

--- a/src/endpoints/Collections.js
+++ b/src/endpoints/Collections.js
@@ -53,7 +53,10 @@ export default class Collections extends Endpoint {
       api: async () => {
         const query = querystring.stringify({ layersPerCollection });
         const response = await this.apiRequest(
-          `projects/${descriptor.projectId}/collections/${descriptor.collectionId}?${query}`
+          `projects/${descriptor.projectId}/collections/${descriptor.collectionId}?${query}`,
+          {
+            headers: requestOptions.headers
+          }
         );
         return wrap(response.data.collections[0], response);
       },
@@ -105,7 +108,9 @@ export default class Collections extends Endpoint {
 
         const response = await this.apiRequest(
           `projects/${projectId}/collections?${query}`,
-          { headers }
+          {
+            headers: requestOptions.headers || headers
+          }
         );
 
         return wrap(response.data.collections, response);

--- a/src/endpoints/Collections.js
+++ b/src/endpoints/Collections.js
@@ -54,9 +54,13 @@ export default class Collections extends Endpoint {
         const query = querystring.stringify({ layersPerCollection });
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}/collections/${descriptor.collectionId}?${query}`,
-          {
-            headers: requestOptions.headers
-          }
+          requestOptions._version
+            ? {
+                headers: {
+                  "Abstract-Api-Version": requestOptions._version
+                }
+              }
+            : { headers }
         );
         return wrap(response.data.collections[0], response);
       },
@@ -108,9 +112,13 @@ export default class Collections extends Endpoint {
 
         const response = await this.apiRequest(
           `projects/${projectId}/collections?${query}`,
-          {
-            headers: requestOptions.headers || headers
-          }
+          requestOptions._version
+            ? {
+                headers: {
+                  "Abstract-Api-Version": requestOptions._version
+                }
+              }
+            : { headers }
         );
 
         return wrap(response.data.collections, response);

--- a/src/types.js
+++ b/src/types.js
@@ -101,7 +101,7 @@ export type ApiRequestOptions = {
 
 export type RequestOptions = {
   transportMode?: ("api" | "cli")[],
-  headers?: { [string]: string }
+  _version?: number
 };
 
 export type RequestConfig<T> = {

--- a/src/types.js
+++ b/src/types.js
@@ -100,7 +100,8 @@ export type ApiRequestOptions = {
 };
 
 export type RequestOptions = {
-  transportMode?: ("api" | "cli")[]
+  transportMode?: ("api" | "cli")[],
+  headers?: { [string]: string }
 };
 
 export type RequestConfig<T> = {


### PR DESCRIPTION
This PR adds the ability to use a custom api version on the collections request. 

Part of https://github.com/goabstract/projects/pull/4159

Project reference: https://github.com/goabstract/ui/pull/2451  