### PR TITLE
chore(cli): replace deprecated usages

### DIFF
--- a/src/endpoints/Changesets.js
+++ b/src/endpoints/Changesets.js
@@ -32,12 +32,10 @@ export default class Changesets extends Endpoint {
 
       cli: async () => {
         const response = await this.cliRequest([
+          "commits",
           "changeset",
-          latestDescriptor.projectId,
-          "--commit",
           latestDescriptor.sha,
-          "--branch",
-          latestDescriptor.branchId
+          `--project-id=${latestDescriptor.projectId}`
         ]);
         return wrap(response.changeset, response);
       },
@@ -58,10 +56,10 @@ export default class Changesets extends Endpoint {
 
       cli: async () => {
         const response = await this.cliRequest([
+          "branches",
           "changeset",
-          descriptor.projectId,
-          "--branch",
-          descriptor.branchId
+          descriptor.branchId,
+          `--project-id=${descriptor.projectId}`
         ]);
         return wrap(response.changeset, response);
       },

--- a/src/endpoints/Collections.js
+++ b/src/endpoints/Collections.js
@@ -60,10 +60,10 @@ export default class Collections extends Endpoint {
 
       cli: async () => {
         const response = await this.cliRequest([
-          "collection",
-          "load",
-          descriptor.projectId,
-          descriptor.collectionId
+          "collections",
+          "get",
+          descriptor.collectionId,
+          `--project-id=${descriptor.projectId}`
         ]);
         return wrap(response.data.collections[0], response);
       },
@@ -114,8 +114,9 @@ export default class Collections extends Endpoint {
       cli: async () => {
         const response = await this.cliRequest([
           "collections",
+          "list",
           descriptor.projectId,
-          ...(descriptor.branchId ? ["--branch", descriptor.branchId] : []),
+          ...(descriptor.branchId ? ["--branch-id", descriptor.branchId] : []),
           ...(layersPerCollection
             ? ["--layersLimit", String(layersPerCollection)]
             : [])

--- a/src/endpoints/Data.js
+++ b/src/endpoints/Data.js
@@ -26,13 +26,13 @@ export default class Data extends Endpoint {
 
       cli: async () => {
         const response = await this.cliRequest([
-          "layer",
-          "data",
-          latestDescriptor.projectId,
-          latestDescriptor.branchId,
-          latestDescriptor.sha,
-          latestDescriptor.fileId,
-          latestDescriptor.layerId
+          "layers",
+          "inspect",
+          latestDescriptor.layerId,
+          `--project-id=${latestDescriptor.projectId}`,
+          `--branch-id=${latestDescriptor.branchId}`,
+          `--sha=${latestDescriptor.sha}`,
+          `--file-id=${latestDescriptor.fileId}`
         ]);
         return wrap(response);
       },

--- a/src/endpoints/Layers.js
+++ b/src/endpoints/Layers.js
@@ -36,12 +36,12 @@ export default class Layers extends Endpoint {
 
       cli: async () => {
         const response = await this.cliRequest([
-          "layer",
-          "meta",
-          latestDescriptor.projectId,
-          latestDescriptor.sha,
-          latestDescriptor.fileId,
-          latestDescriptor.layerId
+          "layers",
+          "info",
+          latestDescriptor.layerId,
+          `--project-id=${latestDescriptor.projectId}`,
+          `--sha=${latestDescriptor.sha}`,
+          `--file-id=${latestDescriptor.fileId}`
         ]);
 
         return wrap(response.layer, response);
@@ -79,9 +79,10 @@ export default class Layers extends Endpoint {
       cli: async () => {
         const args = [
           "layers",
-          latestDescriptor.projectId,
-          latestDescriptor.sha,
-          latestDescriptor.fileId
+          "list",
+          `--project-id=${latestDescriptor.projectId}`,
+          `--sha=${latestDescriptor.sha}`,
+          `--file-id=${latestDescriptor.fileId}`
         ];
 
         if (limit) {

--- a/tests/endpoints/Changesets.test.js
+++ b/tests/endpoints/Changesets.test.js
@@ -26,14 +26,11 @@ describe("commit", () => {
   });
 
   test("cli", async () => {
-    mockCLI(
-      ["changeset", "project-id", "--commit", "sha", "--branch", "branch-id"],
-      {
-        changeset: {
-          id: "changeset-id"
-        }
+    mockCLI(["commits", "changeset", "sha", "--project-id=project-id"], {
+      changeset: {
+        id: "changeset-id"
       }
-    );
+    });
 
     const response = await CLI_CLIENT.changesets.commit({
       branchId: "branch-id",
@@ -66,7 +63,7 @@ describe("branch", () => {
   });
 
   test("cli", async () => {
-    mockCLI(["changeset", "project-id", "--branch", "branch-id"], {
+    mockCLI(["branches", "changeset", "branch-id", "--project-id=project-id"], {
       changeset: {
         id: "changeset-id"
       }

--- a/tests/endpoints/Collections.test.js
+++ b/tests/endpoints/Collections.test.js
@@ -59,15 +59,18 @@ describe("collections", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["collection", "load", "project-id", "collection-id"], {
-        data: {
-          collections: [
-            {
-              id: "collection-id"
-            }
-          ]
+      mockCLI(
+        ["collections", "get", "collection-id", "--project-id=project-id"],
+        {
+          data: {
+            collections: [
+              {
+                id: "collection-id"
+              }
+            ]
+          }
         }
-      });
+      );
 
       const response = await CLI_CLIENT.collections.info({
         projectId: "project-id",
@@ -123,8 +126,9 @@ describe("collections", () => {
       mockCLI(
         [
           "collections",
+          "list",
           "project-id",
-          "--branch",
+          "--branch-id",
           "branch-id",
           "--layersLimit",
           "1337"
@@ -158,7 +162,7 @@ describe("collections", () => {
     });
 
     test("cli - no branch id", async () => {
-      mockCLI(["collections", "project-id"], {
+      mockCLI(["collections", "list", "project-id"], {
         data: {
           collections: [
             {

--- a/tests/endpoints/Data.test.js
+++ b/tests/endpoints/Data.test.js
@@ -32,13 +32,13 @@ describe("data", () => {
     test("cli", async () => {
       mockCLI(
         [
-          "layer",
-          "data",
-          "project-id",
-          "branch-id",
-          "sha",
-          "file-id",
-          "layer-id"
+          "layers",
+          "inspect",
+          "layer-id",
+          "--project-id=project-id",
+          "--branch-id=branch-id",
+          "--sha=sha",
+          "--file-id=file-id"
         ],
         {
           layerId: "layer-id"

--- a/tests/endpoints/Layers.test.js
+++ b/tests/endpoints/Layers.test.js
@@ -32,11 +32,21 @@ describe("layers", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["layer", "meta", "project-id", "sha", "file-id", "layer-id"], {
-        layer: {
-          id: "layer-id"
+      mockCLI(
+        [
+          "layers",
+          "info",
+          "layer-id",
+          "--project-id=project-id",
+          "--sha=sha",
+          "--file-id=file-id"
+        ],
+        {
+          layer: {
+            id: "layer-id"
+          }
         }
-      });
+      );
 
       const response = await CLI_CLIENT.layers.info({
         branchId: "branch-id",
@@ -80,13 +90,22 @@ describe("layers", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["layers", "project-id", "sha", "file-id"], {
-        layers: [
-          {
-            id: "layer-id"
-          }
-        ]
-      });
+      mockCLI(
+        [
+          "layers",
+          "list",
+          "--project-id=project-id",
+          "--sha=sha",
+          "--file-id=file-id"
+        ],
+        {
+          layers: [
+            {
+              id: "layer-id"
+            }
+          ]
+        }
+      );
 
       const response = await CLI_CLIENT.layers.list({
         branchId: "branch-id",
@@ -106,9 +125,10 @@ describe("layers", () => {
       mockCLI(
         [
           "layers",
-          "project-id",
-          "sha",
-          "file-id",
+          "list",
+          "--project-id=project-id",
+          "--sha=sha",
+          "--file-id=file-id",
           "--limit=1",
           "--offset=1",
           "--page-id=page-id",


### PR DESCRIPTION
This PR is pretty basic, it just replaces some CLI commands that are deprecated by the new ones.

The affected commands are `layer`, `collection`, and `changeset`