### PR TITLE
chore: skip-network-read-ops flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abstract-sdk",
-  "version": "8.0.0-beta.13",
+  "version": "8.0.0-beta.14",
   "description": "Universal JavaScript bindings for the Abstract API and CLI",
   "keywords": [
     "abstract",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.3.4",
-    "@elasticprojects/abstract-cli": "^3.5.0",
+    "@elasticprojects/abstract-cli": "^4.3.0",
     "cross-fetch": "^3.0.1",
     "debug": "^4.0.1",
     "flow-typed": "^2.5.1",

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -144,7 +144,13 @@ export default class Endpoint {
 
     const spawnArgs = [
       cliPath,
-      [...tokenArgs, "--api-url", await this.options.apiUrl, ...args]
+      [
+        ...tokenArgs,
+        "--api-url",
+        await this.options.apiUrl,
+        "--skip-network-read-ops",
+        ...args
+      ]
     ];
 
     /* istanbul ignore next */

--- a/yarn.lock
+++ b/yarn.lock
@@ -721,10 +721,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@elasticprojects/abstract-cli@^3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@elasticprojects/abstract-cli/-/abstract-cli-3.5.0.tgz#d0b28a2eda039720243425d5207bbb49da90d6ab"
-  integrity sha512-U+gYbvYkpRY5pQlFJTizQItO39O7elwbcQiYEOXb8cp5fUwsOxiEtBJipCmsBz12aWan6xvgfeMtQw5x1J/tLA==
+"@elasticprojects/abstract-cli@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@elasticprojects/abstract-cli/-/abstract-cli-4.3.0.tgz#81ea247dc45e1d9a77c54b55cd562078ba5848e4"
+  integrity sha512-VG58ccFWICS7tRw4RcLHNexHTDYnT9Jq4+ao6/6d2JHoz1I3YNoH4slI51820TaLsHm7RIgCNBhsufNQ5/55YA==
 
 "@elasticprojects/eslint-config-abstract@^4.1.0":
   version "4.1.0"


### PR DESCRIPTION
Integration tested with the ui project.

This flag being enabled essentially restores operations to how they were prior to CLI 4.3 where no automatic clone/fetch operations will be performed for read commands.