### PR TITLE
Add compiler for IE 11 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [8.0.0](https://github.com/goabstract/abstract-sdk/compare/v8.0.0-beta.7...v8.0.0) (2020-03-06)
+
+
+### Features
+
+* add ability to manage project and section stars ([bc8a31f](https://github.com/goabstract/abstract-sdk/commit/bc8a31fb22fd1f52808ff648df98e72e6968d0ab))
+* add layer dependency filtering options ([#207](https://github.com/goabstract/abstract-sdk/issues/207)) ([88705e8](https://github.com/goabstract/abstract-sdk/commit/88705e88390fcbcbbd57c014ad905321e86b0516))
+* add layer filtering options to cli transport ([#209](https://github.com/goabstract/abstract-sdk/issues/209)) ([42006ab](https://github.com/goabstract/abstract-sdk/commit/42006abca14bc1c6288ea6558ff0fb9aeea79ec0))
+* add review requests to API transport ([09b64c8](https://github.com/goabstract/abstract-sdk/commit/09b64c846af6723b03c4eea062eb0595a222d7cc))
+* support full project CRUD ([#201](https://github.com/goabstract/abstract-sdk/issues/201)) ([a000ca6](https://github.com/goabstract/abstract-sdk/commit/a000ca6b8049ea7f14f1a393e3051869b88c0202))
+* update collections list parameters ([#214](https://github.com/goabstract/abstract-sdk/issues/214)) ([dcb290a](https://github.com/goabstract/abstract-sdk/commit/dcb290a258008d6c56b0ec09ff2b07d029c182e0))
+
+
+### Bug Fixes
+
+* Allow abstract.com domain for share links and expose inferShareId ([#217](https://github.com/goabstract/abstract-sdk/issues/217)) ([7789a92](https://github.com/goabstract/abstract-sdk/commit/7789a927636c2307b6c3cd6734ff0464165061e1))
+* data endpoint needs to pass branch id to cli ([#208](https://github.com/goabstract/abstract-sdk/issues/208)) ([328e5ef](https://github.com/goabstract/abstract-sdk/commit/328e5ef24f2bd1ebba3d0637ad8d6c103d1d1a3c))
+* embed generator ([#213](https://github.com/goabstract/abstract-sdk/issues/213)) ([42f466d](https://github.com/goabstract/abstract-sdk/commit/42f466d43ea631c0aa0a993ea659506e4b009085))
+* support branch pagination ([#221](https://github.com/goabstract/abstract-sdk/issues/221)) ([34e6a42](https://github.com/goabstract/abstract-sdk/commit/34e6a42c51efe494f8c20f2988356e38a38cb2f6))
+
 ## [8.0.0-beta.13](https://github.com/goabstract/abstract-sdk/compare/v8.0.0-beta.7...v8.0.0-beta.13) (2020-03-02)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abstract-sdk",
-  "version": "8.0.0-beta.13",
+  "version": "8.0.0",
   "description": "Universal JavaScript bindings for the Abstract API and CLI",
   "keywords": [
     "abstract",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,8 @@
           "corejs": 2,
           "useBuiltIns": "usage",
           "targets": {
+            "chrome": 58,
+            "ie": 11,
             "node": 10
           },
           "exclude": [


### PR DESCRIPTION
Setup Babel to support older version of browsers (e.g. ie11 and chrome 58).