### PR TITLE
feat: branches merge state

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -153,7 +153,7 @@ interface Branches extends Endpoint {
     descriptor?: ProjectDescriptor,
     options?: RequestOptions & { filter?: "active" | "archived" | "mine", search?: string }
   ): Promise<Branch[]>;
-  mergeState(descriptor: BranchDescriptor, parent?: string): Promise<BranchMergeState>;
+  mergeState(descriptor: BranchDescriptor, options?: { parent?: string }): Promise<BranchMergeState>;
 }
 
 interface Changesets extends Endpoint {

--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -153,6 +153,7 @@ interface Branches extends Endpoint {
     descriptor?: ProjectDescriptor,
     options?: RequestOptions & { filter?: "active" | "archived" | "mine", search?: string }
   ): Promise<Branch[]>;
+  mergeState(descriptor: BranchDescriptor, parent?: string): Promise<BranchMergeState>;
 }
 
 interface Changesets extends Endpoint {

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -271,7 +271,7 @@ A branch merge state is a description of whether a branch can be cleanly merged 
 
 ![CLI][cli-icon] ![API][api-icon]
 
-`branches.mergeState(BranchDescriptor, string): Promise<BranchMergeState>`
+`branches.mergeState(BranchDescriptor, options?: { parent?: string }): Promise<BranchMergeState>`
 
 Load the merge state for a specific branch in a project.
 
@@ -282,7 +282,7 @@ abstract.branches.mergeState({
 });
 ```
 
-> Note: the optional fields in `BranchMergeState` are only available when using the [API transport](/docs/transports). The API transport only returns states `CLEAN` or `NEEDS_UPDATE`, while the CLI transport may return all three possible states.
+> Note: The API and CLI [transports](/docs/transports) behave differently for merge state. The CLI transport ignores `options.parent`, and _only_ returns one of the three possible merge states (no other fields are included). The API transport includes a value for each field of `BranchMergeState`, and only returns statuses `CLEAN` or `NEEDS_UPDATE`.
 
 ## Changesets
 

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -251,6 +251,38 @@ abstract.branches.info({
 });
 ```
 
+## BranchMergeState
+
+A branch merge state is a description of whether a branch can be cleanly merged to its parent branch.
+
+### The branch merge state object
+
+| Property               | Type     | Description                                                                                       |
+|------------------------|----------|---------------------------------------------------------------------------------------------------|
+| `state`                | `string` | The merge state of the branch relative to its parent branch. May be one of `CLEAN`, `NEEDS_UPDATE`, or `NEEDS_REMOTE_UPDATE` |
+| `parentId`             | `string` | UUID of the parent btanch                                                                         |
+| `parentCommit`         | `string` | SHA that represents the latest commit on the parent branch                                        |
+| `branchId`             | `string` | UUID identifier of the branch, or the string "master"                                             |
+| `branchCommit`         | `string` | SHA that represents the latest commit on the branch                                               |
+| `ahead`                | `number` | The number of commits that the branch is ahead of its parent                                      |
+| `behind`               | `number` | The number of commits that the branch is behind its parent                                        |
+
+### Merge state of a branch
+
+![CLI][cli-icon] ![API][api-icon]
+
+`branches.mergeState(BranchDescriptor, string): Promise<BranchMergeState>`
+
+Load the merge state for a specific branch in a project.
+
+```js
+abstract.branches.mergeState({
+  projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78",
+  branchId: "252e9141-5cfc-4f4e-823b-a85f4cfd9a32"
+});
+```
+
+> Note: the optional fields in `BranchMergeState` are only available when using the [API transport](/docs/transports). The API transport only returns states `CLEAN` or `NEEDS_UPDATE`, while the CLI transport may return all three possible states.
 
 ## Changesets
 

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -88,7 +88,7 @@ export default class Branches extends Endpoint {
       api: async () => {
         let requestUrl = `projects/${descriptor.projectId}/branches/${descriptor.branchId}/merge_state`;
         if (parent) {
-          const query = querystring.stringify({ parent_id: parent });
+          const query = querystring.stringify({ parentId: parent });
           requestUrl = `${requestUrl}?${query}`;
         }
         const response = await this.apiRequest(requestUrl, { headers });

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -83,16 +83,13 @@ export default class Branches extends Endpoint {
     });
   }
 
-  mergeState(
-    descriptor: BranchDescriptor,
-    parent?: string
-  ) {
+  mergeState(descriptor: BranchDescriptor, parent?: string) {
     return this.configureRequest<Promise<BranchMergeState>>({
       api: async () => {
         let requestUrl = `projects/${descriptor.projectId}/branches/${descriptor.branchId}/merge_state`;
         if (parent) {
           const query = querystring.stringify({ parent_id: parent });
-          requestUrl = `${requestUrl}?${query}`
+          requestUrl = `${requestUrl}?${query}`;
         }
         const response = await this.apiRequest(requestUrl, { headers });
         return wrap(response.data, response);
@@ -106,7 +103,7 @@ export default class Branches extends Endpoint {
           `--project-id=${descriptor.projectId}`
         ]);
 
-        return wrap(response, response)
+        return wrap(response, response);
       }
     });
   }

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -83,13 +83,16 @@ export default class Branches extends Endpoint {
     });
   }
 
-  mergeState(descriptor: BranchDescriptor, parent?: string) {
+  mergeState(descriptor: BranchDescriptor, options: { parent?: string }) {
     return this.configureRequest<Promise<BranchMergeState>>({
       api: async () => {
         let requestUrl = `projects/${descriptor.projectId}/branches/${descriptor.branchId}/merge_state`;
-        if (parent) {
-          const query = querystring.stringify({ parentId: parent });
-          requestUrl = `${requestUrl}?${query}`;
+        if (options) {
+          const { parent } = options;
+          if (parent) {
+            const query = querystring.stringify({ parentId: parent });
+            requestUrl = `${requestUrl}?${query}`;
+          }
         }
         const response = await this.apiRequest(requestUrl, { headers });
         return wrap(response.data, response);

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -83,7 +83,7 @@ export default class Branches extends Endpoint {
     });
   }
 
-  mergeState(descriptor: BranchDescriptor, options: { parent?: string }) {
+  mergeState(descriptor: BranchDescriptor, options?: { parent?: string }) {
     return this.configureRequest<Promise<BranchMergeState>>({
       api: async () => {
         let requestUrl = `projects/${descriptor.projectId}/branches/${descriptor.branchId}/merge_state`;

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -3,6 +3,7 @@ import querystring from "query-string";
 import type {
   Branch,
   BranchDescriptor,
+  BranchMergeState,
   ListOptions,
   ProjectDescriptor,
   RequestOptions
@@ -79,6 +80,34 @@ export default class Branches extends Endpoint {
       },
 
       requestOptions
+    });
+  }
+
+  mergeState(
+    descriptor: BranchDescriptor,
+    parent?: string
+  ) {
+    return this.configureRequest<Promise<BranchMergeState>>({
+      api: async () => {
+        let requestUrl = `projects/${descriptor.projectId}/branches/${descriptor.branchId}/merge_state`;
+        if (parent) {
+          const query = querystring.stringify({ parent_id: parent });
+          requestUrl = `${requestUrl}?${query}`
+        }
+        const response = await this.apiRequest(requestUrl, { headers });
+        return wrap(response.data, response);
+      },
+
+      cli: async () => {
+        const response = await this.cliRequest([
+          "branches",
+          "merge-state",
+          descriptor.branchId,
+          `--project-id=${descriptor.projectId}`
+        ]);
+
+        return wrap(response, response)
+      }
     });
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -785,6 +785,19 @@ export type Branch = {
   user: User
 };
 
+export type BranchMergeState = {
+  state:
+    | "CLEAN"
+    | "NEEDS_UPDATE"
+    | "NEEDS_REMOTE_UPDATE",
+  parentId?: string,
+  parentCommit?: string,
+  branchId?: string,
+  branchCommit?: string,
+  ahead?: number,
+  behind?: number
+};
+
 export type ChangesetStatus =
   | "added"
   | "deleted"

--- a/src/types.js
+++ b/src/types.js
@@ -785,11 +785,10 @@ export type Branch = {
   user: User
 };
 
+export type MergeState = "CLEAN" | "NEEDS_UPDATE" | "NEEDS_REMOTE_UPDATE";
+
 export type BranchMergeState = {
-  state:
-    | "CLEAN"
-    | "NEEDS_UPDATE"
-    | "NEEDS_REMOTE_UPDATE",
+  state: MergeState,
   parentId?: string,
   parentCommit?: string,
   branchId?: string,

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -193,4 +193,59 @@ describe("branches", () => {
       }
     });
   });
+
+  describe("mergeState", () => {
+    test("api - without parent", async () => {
+      mockAPI("/projects/project-id/branches/branch-id/merge_state", {
+        data: {
+          state: "CLEAN"
+        }
+      });
+
+      const response = await API_CLIENT.branches.mergeState({
+        branchId: "branch-id",
+        projectId: "project-id"
+      }, null);
+
+      expect(response).toEqual({
+        state: "CLEAN"
+      });
+    });
+
+    test("api - with parent", async () => {
+      try {
+      mockAPI("/projects/project-id/branches/branch-id/merge_state?parent_id=parent-id", {
+        data: {
+          state: "CLEAN"
+        }
+      });
+
+      const response = await API_CLIENT.branches.mergeState({
+        branchId: "branch-id",
+        projectId: "project-id"
+      }, "parent-id");
+
+      expect(response).toEqual({
+        state: "CLEAN"
+      });
+      } catch (e) {
+        console.log(e);
+      }
+    });
+
+    test("cli", async () => {
+      mockCLI(["branches", "merge-state", "branch-id", "--project-id=project-id"], {
+        state: "CLEAN"
+      });
+
+      const response = await CLI_CLIENT.branches.mergeState({
+        branchId: "branch-id",
+        projectId: "project-id"
+      }, null);
+
+      expect(response).toEqual({
+        state: "CLEAN"
+      });
+    });
+  });
 });

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -195,7 +195,7 @@ describe("branches", () => {
   });
 
   describe("mergeState", () => {
-    test("api - without parent", async () => {
+    test("api - without options", async () => {
       mockAPI("/projects/project-id/branches/branch-id/merge_state", {
         data: {
           state: "CLEAN"
@@ -212,7 +212,26 @@ describe("branches", () => {
       });
     });
 
-    test("api - with parent", async () => {
+    test("api - with options", async () => {
+      mockAPI("/projects/project-id/branches/branch-id/merge_state", {
+        data: {
+          state: "CLEAN"
+        }
+      });
+
+      const response = await API_CLIENT.branches.mergeState(
+        {
+          branchId: "branch-id",
+          projectId: "project-id"
+        },
+        {}
+      );
+      expect(response).toEqual({
+        state: "CLEAN"
+      });
+    });
+
+    test("api - with options and parent", async () => {
       mockAPI(
         "/projects/project-id/branches/branch-id/merge_state?parentId=parent-id",
         {
@@ -227,9 +246,8 @@ describe("branches", () => {
           branchId: "branch-id",
           projectId: "project-id"
         },
-        "parent-id"
+        { parent: "parent-id" }
       );
-
       expect(response).toEqual({
         state: "CLEAN"
       });

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -213,30 +213,35 @@ describe("branches", () => {
     });
 
     test("api - with parent", async () => {
-      try {
-      mockAPI("/projects/project-id/branches/branch-id/merge_state?parent_id=parent-id", {
-        data: {
-          state: "CLEAN"
+      mockAPI(
+        "/projects/project-id/branches/branch-id/merge_state?parent_id=parent-id",
+        {
+          data: {
+            state: "CLEAN"
+          }
         }
-      });
+      );
 
-      const response = await API_CLIENT.branches.mergeState({
-        branchId: "branch-id",
-        projectId: "project-id"
-      }, "parent-id");
+      const response = await API_CLIENT.branches.mergeState(
+        {
+          branchId: "branch-id",
+          projectId: "project-id"
+        },
+        "parent-id"
+      );
 
       expect(response).toEqual({
         state: "CLEAN"
       });
-      } catch (e) {
-        console.log(e);
-      }
     });
 
     test("cli", async () => {
-      mockCLI(["branches", "merge-state", "branch-id", "--project-id=project-id"], {
-        state: "CLEAN"
-      });
+      mockCLI(
+        ["branches", "merge-state", "branch-id", "--project-id=project-id"],
+        {
+          state: "CLEAN"
+        }
+      );
 
       const response = await CLI_CLIENT.branches.mergeState({
         branchId: "branch-id",

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -205,7 +205,7 @@ describe("branches", () => {
       const response = await API_CLIENT.branches.mergeState({
         branchId: "branch-id",
         projectId: "project-id"
-      }, null);
+      });
 
       expect(response).toEqual({
         state: "CLEAN"
@@ -241,7 +241,7 @@ describe("branches", () => {
       const response = await CLI_CLIENT.branches.mergeState({
         branchId: "branch-id",
         projectId: "project-id"
-      }, null);
+      });
 
       expect(response).toEqual({
         state: "CLEAN"

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -214,7 +214,7 @@ describe("branches", () => {
 
     test("api - with parent", async () => {
       mockAPI(
-        "/projects/project-id/branches/branch-id/merge_state?parent_id=parent-id",
+        "/projects/project-id/branches/branch-id/merge_state?parentId=parent-id",
         {
           data: {
             state: "CLEAN"


### PR DESCRIPTION
Adds the ability to query the branch merge state for both the API and CLI transports.

Note that CLI only provides the `state` while the API returns more detailed information.