### PR TITLE
fix: Respect transportMode for branches.mergeState

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -271,7 +271,7 @@ A branch merge state is a description of whether a branch can be cleanly merged 
 
 ![CLI][cli-icon] ![API][api-icon]
 
-`branches.mergeState(BranchDescriptor, options?: { parentId?: string }): Promise<BranchMergeState>`
+`branches.mergeState(BranchDescriptor, { ...RequestOptions, parentId?: string }): Promise<BranchMergeState>`
 
 Load the merge state for a specific branch in a project.
 

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -260,7 +260,7 @@ A branch merge state is a description of whether a branch can be cleanly merged 
 | Property               | Type     | Description                                                                                       |
 |------------------------|----------|---------------------------------------------------------------------------------------------------|
 | `state`                | `string` | The merge state of the branch relative to its parent branch. May be one of `CLEAN`, `NEEDS_UPDATE`, or `NEEDS_REMOTE_UPDATE` |
-| `parentId`             | `string` | UUID of the parent btanch                                                                         |
+| `parentId`             | `string` | UUID of the parent branch                                                                         |
 | `parentCommit`         | `string` | SHA that represents the latest commit on the parent branch                                        |
 | `branchId`             | `string` | UUID identifier of the branch, or the string "master"                                             |
 | `branchCommit`         | `string` | SHA that represents the latest commit on the branch                                               |
@@ -271,7 +271,7 @@ A branch merge state is a description of whether a branch can be cleanly merged 
 
 ![CLI][cli-icon] ![API][api-icon]
 
-`branches.mergeState(BranchDescriptor, options?: { parent?: string }): Promise<BranchMergeState>`
+`branches.mergeState(BranchDescriptor, options?: { parentId?: string }): Promise<BranchMergeState>`
 
 Load the merge state for a specific branch in a project.
 
@@ -282,7 +282,7 @@ abstract.branches.mergeState({
 });
 ```
 
-> Note: The API and CLI [transports](/docs/transports) behave differently for merge state. The CLI transport ignores `options.parent`, and _only_ returns one of the three possible merge states (no other fields are included). The API transport includes a value for each field of `BranchMergeState`, and only returns statuses `CLEAN` or `NEEDS_UPDATE`.
+> Note: The API and CLI [transports](/docs/transports) behave differently for merge state. The CLI transport ignores `options.parentId`, and _only_ returns one of the three possible merge states (no other fields are included). The API transport includes a value for each field of `BranchMergeState`, and only returns statuses `CLEAN` or `NEEDS_UPDATE`.
 
 ## Changesets
 

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -83,16 +83,18 @@ export default class Branches extends Endpoint {
     });
   }
 
-  mergeState(descriptor: BranchDescriptor, options?: { parent?: string }) {
+  mergeState(
+    descriptor: BranchDescriptor,
+    options?: { ...RequestOptions, parentId?: string } = {}
+  ) {
+    const { parentId, ...requestOptions } = options;
+
     return this.configureRequest<Promise<BranchMergeState>>({
       api: async () => {
         let requestUrl = `projects/${descriptor.projectId}/branches/${descriptor.branchId}/merge_state`;
-        if (options) {
-          const { parent } = options;
-          if (parent) {
-            const query = querystring.stringify({ parentId: parent });
-            requestUrl = `${requestUrl}?${query}`;
-          }
+        if (parentId) {
+          const query = querystring.stringify({ parentId });
+          requestUrl = `${requestUrl}?${query}`;
         }
         const response = await this.apiRequest(requestUrl, { headers });
         return wrap(response.data, response);
@@ -107,7 +109,9 @@ export default class Branches extends Endpoint {
         ]);
 
         return wrap(response, response);
-      }
+      },
+
+      requestOptions
     });
   }
 }

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -246,7 +246,7 @@ describe("branches", () => {
           branchId: "branch-id",
           projectId: "project-id"
         },
-        { parent: "parent-id" }
+        { parentId: "parent-id" }
       );
       expect(response).toEqual({
         state: "CLEAN"


### PR DESCRIPTION
When testing this in the front end, I noticed that an API call was always fired when accessing a branch's merge state, even when passing `transportMode: ["cli"]`. This PR fixes the issue by including `RequestOptions` in the endpoint declaration.

I also changed the `parent` parameter to `parentId`. It felt more intuitive to me, but if we don't want to make that change I can easily revert.