### PR TITLE
fix: Return branch merge state at top level of CLI response

### DIFF
--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -108,7 +108,7 @@ export default class Branches extends Endpoint {
           `--project-id=${descriptor.projectId}`
         ]);
 
-        return wrap(response, response);
+        return wrap(response.data, response);
       },
 
       requestOptions

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -257,7 +257,9 @@ describe("branches", () => {
       mockCLI(
         ["branches", "merge-state", "branch-id", "--project-id=project-id"],
         {
-          state: "CLEAN"
+          data: {
+            state: "CLEAN"
+          }
         }
       );
 


### PR DESCRIPTION
The CLI returns a branch's merge state nested under a `data` key. This PR updates the SDK so we return the merge state directly (which is the expected response according to the docs).