### PR TITLE
feat: Assets cli support

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -135,7 +135,7 @@ abstract.assets.commit({
 
 ### Export an asset file
 
-![API][api-icon]
+![API][api-icon] ![CLI][cli-icon]
 
 `asset.raw(AssetDescriptor, RawOptions}): Promise<ArrayBuffer>`
 
@@ -151,18 +151,48 @@ abstract.assets.raw({
 The resulting `ArrayBuffer` can be also be used with node `fs` APIs directly. For example, it's possible to write the image to disk manually after post-processing it:
 
 ```js
-const arrayBuffer = await abstract.assets.raw({
-  assetId: "fcd67bab-e5c3-4679-b879-daa5d5746cc2",
-  projectId: "b8bf5540-6e1e-11e6-8526-2d315b6ef48f"
-}, {
-  disableWrite: true
-});
+const arrayBuffer = await abstract.assets.raw(
+  {
+    assetId: "fcd67bab-e5c3-4679-b879-daa5d5746cc2",
+    projectId: "b8bf5540-6e1e-11e6-8526-2d315b6ef48f"
+  },
+  {
+    disableWrite: true
+  }
+);
 
 processedBuffer = postProcess(arrayBuffer);
 
-fs.writeFile("asset.png", Buffer.from(processedBuffer), (err) => {
+fs.writeFile("asset.png", Buffer.from(processedBuffer), err => {
   if (err) throw err;
   console.log("Asset image written!");
+});
+```
+
+### Check for local changes in asset
+
+![CLI][cli-icon]
+
+`asset.hasChanges(AssetHasChanges, RawOptions}): Promise<AssetHasChangesBool>`
+
+```js
+// Check if assets have been changed
+const assets = await abstract.assets.file({
+  projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78",
+  sha: "latest"
+});
+```
+
+### Export only changed assets
+
+![CLI][cli-icon]
+
+`asset.exportChanged(AssetDescriptor, RawOptions}): Promise<AssetGenerateProgress[]>`
+
+```js
+const assets = await abstract.assets.exportChanged({
+  projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78",
+  sha: "latest"
 });
 ```
 

--- a/src/endpoints/Assets.js
+++ b/src/endpoints/Assets.js
@@ -134,7 +134,6 @@ export default class Assets extends Endpoint {
           `--urls=${latestDescriptor.url}`,
           `--filenames=${latestDescriptor.filename}`,
           `--output=${latestDescriptor.output || "asset"}`,
-          `--sha=${latestDescriptor.sha}`,
           latestDescriptor.expand ? `--expand` : ``
         ]);
 

--- a/src/endpoints/Assets.js
+++ b/src/endpoints/Assets.js
@@ -5,7 +5,6 @@ import { isNodeEnvironment, wrap } from "../util/helpers";
 import type {
   Asset,
   AssetDescriptor,
-  AssetHasChanges,
   BranchCommitDescriptor,
   FileDescriptor,
   ListOptions,
@@ -16,7 +15,7 @@ import type {
 import Endpoint from "../endpoints/Endpoint";
 
 export default class Assets extends Endpoint {
-  async info(descriptor: AssetDescriptor, requestOptions: RequestOptions = {}) {
+  info(descriptor: AssetDescriptor, requestOptions: RequestOptions = {}) {
     return this.configureRequest<Promise<Asset>>({
       api: async () => {
         const response = await this.apiRequest(
@@ -117,9 +116,9 @@ export default class Assets extends Endpoint {
           "assets",
           "download",
           `--urls=${latestDescriptor.url}`,
-          `--filenames=${latestDescriptor.filename}`,
-          `--output=${latestDescriptor.output}`,
-          latestDescriptor.expand ? `--expand` : ``
+          `--filenames=${options.filename}`,
+          `--output=${options.output}`,
+          options.expand ? `--expand` : ``
         ]);
 
         return wrap(response, response);
@@ -128,7 +127,10 @@ export default class Assets extends Endpoint {
     });
   }
 
-  async hasChanges(descriptor: AssetHasChanges, options: RawOptions = {}) {
+  async hasChanges(
+    descriptor: BranchCommitDescriptor,
+    options: RawOptions = {}
+  ) {
     const { disableWrite, filename, ...requestOptions } = options;
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor

--- a/src/endpoints/Assets.js
+++ b/src/endpoints/Assets.js
@@ -50,7 +50,7 @@ export default class Assets extends Endpoint {
     });
   }
 
-  async file(descriptor: FileDescriptor, options: ListOptions = {}) {
+  file(descriptor: FileDescriptor, options: ListOptions = {}) {
     const { limit, offset, ...requestOptions } = options;
 
     return this.createCursor<Promise<Asset[]>>(

--- a/src/types.js
+++ b/src/types.js
@@ -168,7 +168,13 @@ export type UserDescriptor = {|
 
 export type AssetDescriptor = {|
   assetId: string,
-  projectId: string
+  projectId: string,
+  branchId: string,
+  sha: string,
+  url: string,
+  filename: string,
+  output: string,
+  expand: boolean
 |};
 
 export type ReviewStatus = "REQUESTED" | "REJECTED" | "APPROVED";

--- a/src/types.js
+++ b/src/types.js
@@ -119,7 +119,9 @@ export type ListOptions = {
 export type RawOptions = {
   ...RequestOptions,
   disableWrite?: boolean,
-  filename?: string
+  filename?: string,
+  output?: string,
+  expand?: boolean
 };
 
 export type RawProgressOptions = {
@@ -166,19 +168,8 @@ export type UserDescriptor = {|
   userId: string
 |};
 
-export type AssetDescriptor = {
+export type AssetDescriptor = {|
   assetId: string,
-  projectId: string,
-  branchId: string,
-  sha: string,
-  url: string,
-  filename: string,
-  output: string,
-  expand: boolean | false
-};
-
-export type AssetHasChanges = {|
-  sha: string,
   projectId: string
 |};
 

--- a/src/types.js
+++ b/src/types.js
@@ -166,7 +166,7 @@ export type UserDescriptor = {|
   userId: string
 |};
 
-export type AssetDescriptor = {|
+export type AssetDescriptor = {
   assetId: string,
   projectId: string,
   branchId: string,
@@ -174,7 +174,24 @@ export type AssetDescriptor = {|
   url: string,
   filename: string,
   output: string,
-  expand: boolean
+  expand: boolean | false
+};
+
+export type AssetHasChanges = {|
+  sha: string,
+  projectId: string
+|};
+
+export type AssetGenerateProgress = {|
+  type: "GENERATE_ASSETS_PROGRESS",
+  stepName: string,
+  completed: number,
+  total: number,
+  percentage: number
+|};
+
+export type AssetHasChangesBool = {|
+  hasChangedAssets: boolean
 |};
 
 export type ReviewStatus = "REQUESTED" | "REJECTED" | "APPROVED";

--- a/tests/endpoints/Assets.test.js
+++ b/tests/endpoints/Assets.test.js
@@ -1,5 +1,11 @@
 // @flow
-import { mockAPI, mockObjectAPI, API_CLIENT } from "../../src/util/testing";
+import {
+  mockObjectAPI,
+  mockAPI,
+  mockCLI,
+  API_CLIENT,
+  CLI_CLIENT
+} from "../../src/util/testing";
 
 describe("assets", () => {
   describe("info", () => {
@@ -50,6 +56,21 @@ describe("assets", () => {
       );
 
       expect(response).toBeInstanceOf(ArrayBuffer);
+
+      // test("cli", async () => {
+      //   mockCLI(["assets", "download", "--urls=url", "--filenames=filename"], {
+      //     success: true
+      //   });
+
+      //   const response = await CLI_CLIENT.assets.raw({
+      //     url: "url",
+      //     filename: "filename"
+      //   });
+
+      //   expect(response).toEqual({
+      //     success: true
+      //   });
+      // });
     });
 
     test("api - browser", async () => {
@@ -126,6 +147,26 @@ describe("assets", () => {
           id: "asset-id"
         }
       ]);
+    });
+  });
+
+  describe("hasChanges", () => {
+    test("cli", async () => {
+      mockCLI(
+        ["assets", "has-changes", "--project-id=project-id", "--sha=sha"],
+        {
+          hasChangedAssets: false
+        }
+      );
+
+      const response = await CLI_CLIENT.assets.hasChanges({
+        projectId: "project-id",
+        sha: "sha"
+      });
+
+      expect(response).toEqual({
+        hasChangedAssets: false
+      });
     });
   });
 });


### PR DESCRIPTION
Hi, I've been working on adding up cli to Assets endpoint lately, I currently have an issue with export (a.k.a. raw).
The server sends assets by parts (like 1/6 is exported), and our SDK just squashes these JSON objects into a string and then reproduces an error (Unexpected token { in JSON at position ...).
Do we have any already made solutions? Might `cursorPromise` help?
P.S. I don't want to merge right now, just wanted to ask a question