### PR TITLE
feat: allow observing analytics on endpoints

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -1826,9 +1826,17 @@ type AccessTokenOption =
   | (() => AccessToken) // TODO: Deprecate
   | (() => Promise<AccessToken>);
 
+type EndpointAnalytic = {
+  duration: number,
+  endpoint: string,
+  request: string,
+  transportMode: "api" | "cli"
+};
+
 type CommandOptions = {
   accessToken: AccessTokenOption,
   apiUrl: string | Promise<string>,
+  analyticsCallback: (analytics: EndpointAnalytic) => any,
   assetUrl: string | Promise<string>,
   previewUrl: string | Promise<string>,
   transportMode: ("api" | "cli")[],

--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -1826,7 +1826,7 @@ type AccessTokenOption =
   | (() => AccessToken) // TODO: Deprecate
   | (() => Promise<AccessToken>);
 
-type EndpointAnalytic = {
+type EndpointMetric = {
   duration: number,
   endpoint: string,
   request: string,
@@ -1836,7 +1836,7 @@ type EndpointAnalytic = {
 type CommandOptions = {
   accessToken: AccessTokenOption,
   apiUrl: string | Promise<string>,
-  analyticsCallback: (analytics: EndpointAnalytic) => any,
+  analyticsCallback: (analytics: EndpointMetric) => any,
   assetUrl: string | Promise<string>,
   previewUrl: string | Promise<string>,
   transportMode: ("api" | "cli")[],

--- a/src/endpoints/Activities.js
+++ b/src/endpoints/Activities.js
@@ -14,8 +14,9 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 export default class Activities extends Endpoint {
+  name = "activities";
   info(descriptor: ActivityDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Activity>>({
+    return this.configureRequest<Promise<Activity>>("info", {
       api: async () => {
         const response = await this.apiRequest(
           `activities/${descriptor.activityId}`
@@ -33,6 +34,7 @@ export default class Activities extends Endpoint {
     const { limit, offset, ...requestOptions } = options;
 
     return this.createCursor<CursorPromise<Activity[]>>(
+      "list",
       (nextOffset = offset) => ({
         api: () => {
           const query = querystring.stringify({

--- a/src/endpoints/Assets.js
+++ b/src/endpoints/Assets.js
@@ -14,8 +14,10 @@ import type {
 import Endpoint from "../endpoints/Endpoint";
 
 export default class Assets extends Endpoint {
+  name = "assets";
+
   info(descriptor: AssetDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Asset>>({
+    return this.configureRequest<Promise<Asset>>("info", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}/assets/${descriptor.assetId}`
@@ -34,7 +36,7 @@ export default class Assets extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<Asset[]>>({
+    return this.configureRequest<Promise<Asset[]>>("commit", {
       api: async () => {
         const query = querystring.stringify({ sha: latestDescriptor.sha });
 
@@ -52,6 +54,7 @@ export default class Assets extends Endpoint {
     const { limit, offset, ...requestOptions } = options;
 
     return this.createCursor<Promise<Asset[]>>(
+      "file",
       (nextOffset = offset) => ({
         api: () => {
           const query = querystring.stringify({
@@ -73,7 +76,7 @@ export default class Assets extends Endpoint {
   raw(descriptor: AssetDescriptor, options: RawOptions = {}) {
     const { disableWrite, filename, ...requestOptions } = options;
 
-    return this.configureRequest<Promise<ArrayBuffer>>({
+    return this.configureRequest<Promise<ArrayBuffer>>("raw", {
       api: async () => {
         const asset = await this.info(descriptor);
         const assetUrl = await this.options.objectUrl;

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -18,8 +18,10 @@ const headers = {
 };
 
 export default class Branches extends Endpoint {
+  name = "branches";
+
   info(descriptor: BranchDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Branch>>({
+    return this.configureRequest<Promise<Branch>>("info", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}/branches/${descriptor.branchId}`,
@@ -54,7 +56,7 @@ export default class Branches extends Endpoint {
   ) {
     const { limit, offset, filter, search, ...requestOptions } = options;
 
-    return this.configureRequest<Promise<Branch[]>>({
+    return this.configureRequest<Promise<Branch[]>>("list", {
       api: async () => {
         const query = querystring.stringify({ limit, offset, filter, search });
         const requestUrl = descriptor
@@ -89,7 +91,7 @@ export default class Branches extends Endpoint {
   ) {
     const { parentId, ...requestOptions } = options;
 
-    return this.configureRequest<Promise<BranchMergeState>>({
+    return this.configureRequest<Promise<BranchMergeState>>("mergeState", {
       api: async () => {
         let requestUrl = `projects/${descriptor.projectId}/branches/${descriptor.branchId}/merge_state`;
         if (parentId) {

--- a/src/endpoints/Changesets.js
+++ b/src/endpoints/Changesets.js
@@ -14,6 +14,8 @@ const headers = {
 };
 
 export default class Changesets extends Endpoint {
+  name = "changesets";
+
   async commit(
     descriptor: BranchCommitDescriptor,
     requestOptions: RequestOptions = {}
@@ -22,7 +24,7 @@ export default class Changesets extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<Changeset>>({
+    return this.configureRequest<Promise<Changeset>>("commit", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/commits/${latestDescriptor.sha}/changeset`,
@@ -46,7 +48,7 @@ export default class Changesets extends Endpoint {
   }
 
   branch(descriptor: BranchDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Changeset>>({
+    return this.configureRequest<Promise<Changeset>>("branch", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}/branches/${descriptor.branchId}/changeset`,
@@ -70,7 +72,7 @@ export default class Changesets extends Endpoint {
   }
 
   project(descriptor: ProjectDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Changeset>>({
+    return this.configureRequest<Promise<Changeset>>("project", {
       cli: async () => {
         const response = await this.cliRequest([
           "projects",

--- a/src/endpoints/CollectionLayers.js
+++ b/src/endpoints/CollectionLayers.js
@@ -11,6 +11,8 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 export default class CollectionLayers extends Endpoint {
+  name = "collectionLayers";
+
   add(
     descriptor: CollectionDescriptor,
     layer: NewCollectionLayer,
@@ -18,7 +20,7 @@ export default class CollectionLayers extends Endpoint {
   ) {
     layer = { ...layer, collectionId: descriptor.collectionId };
 
-    return this.configureRequest<Promise<CollectionLayer>>({
+    return this.configureRequest<Promise<CollectionLayer>>("add", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}/collection_layers`,
@@ -44,7 +46,7 @@ export default class CollectionLayers extends Endpoint {
       return { ...collectionLayer, id: layerId };
     });
 
-    return this.configureRequest<Promise<CollectionLayer>>({
+    return this.configureRequest<Promise<CollectionLayer>>("addMany", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}/collection_layers/create_many`,
@@ -67,7 +69,7 @@ export default class CollectionLayers extends Endpoint {
     descriptor: CollectionLayerDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<void>>({
+    return this.configureRequest<Promise<void>>("remove", {
       api: () => {
         return this.apiRequest(
           `projects/${descriptor.projectId}/collection_layers/${descriptor.collectionLayerId}`,
@@ -86,7 +88,7 @@ export default class CollectionLayers extends Endpoint {
     order: number,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<CollectionLayer[]>>({
+    return this.configureRequest<Promise<CollectionLayer[]>>("move", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}/collection_layers/${descriptor.collectionLayerId}/move`,
@@ -107,7 +109,7 @@ export default class CollectionLayers extends Endpoint {
     layer: UpdatedCollectionLayer,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<CollectionLayer>>({
+    return this.configureRequest<Promise<CollectionLayer>>("update", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}/collection_layers/${descriptor.collectionLayerId}`,

--- a/src/endpoints/Collections.js
+++ b/src/endpoints/Collections.js
@@ -17,12 +17,14 @@ import { wrap } from "../util/helpers";
 const API_VERSION = 16;
 
 export default class Collections extends Endpoint {
+  name = "collections";
+
   create(
     descriptor: ProjectDescriptor,
     collection: NewCollection,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Collection>>({
+    return this.configureRequest<Promise<Collection>>("create", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}/collections`,
@@ -47,7 +49,7 @@ export default class Collections extends Endpoint {
   ) {
     const { layersPerCollection, ...requestOptions } = options;
 
-    return this.configureRequest<Promise<Collection>>({
+    return this.configureRequest<Promise<Collection>>("info", {
       api: async () => {
         const query = querystring.stringify({ layersPerCollection });
         const response = await this.apiRequest(
@@ -91,7 +93,7 @@ export default class Collections extends Endpoint {
       ...requestOptions
     } = options;
 
-    return this.configureRequest<Promise<Collection[]>>({
+    return this.configureRequest<Promise<Collection[]>>("list", {
       api: async () => {
         const { projectId, ...sanitizedDescriptor } = descriptor;
         const query = querystring.stringify({
@@ -141,7 +143,7 @@ export default class Collections extends Endpoint {
     collection: UpdatedCollection,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Collection>>({
+    return this.configureRequest<Promise<Collection>>("update", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}/collections/${descriptor.collectionId}`,

--- a/src/endpoints/Comments.js
+++ b/src/endpoints/Comments.js
@@ -15,6 +15,8 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 export default class Comments extends Endpoint {
+  name = "comments";
+
   async create(
     descriptor:
       | BranchDescriptor
@@ -33,7 +35,7 @@ export default class Comments extends Endpoint {
       );
     }
 
-    return this.configureRequest<Promise<Comment>>({
+    return this.configureRequest<Promise<Comment>>("create", {
       api: async () => {
         const body = {
           ...comment,
@@ -53,7 +55,7 @@ export default class Comments extends Endpoint {
   }
 
   info(descriptor: CommentDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Comment>>({
+    return this.configureRequest<Promise<Comment>>("info", {
       api: async () => {
         const response = await this.apiRequest(
           `comments/${descriptor.commentId}`
@@ -80,6 +82,7 @@ export default class Comments extends Endpoint {
     }
 
     return this.createCursor<Promise<Comment[]>>(
+      "list",
       (nextOffset = offset) => ({
         api: () => {
           const query = querystring.stringify({

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -14,6 +14,8 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 export default class Commits extends Endpoint {
+  name = "commits";
+
   info(
     descriptor:
       | BranchCommitDescriptor
@@ -22,7 +24,7 @@ export default class Commits extends Endpoint {
       | LayerVersionDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Commit>>({
+    return this.configureRequest<Promise<Commit>>("info", {
       api: async () => {
         // loading commits with a share token requires a branchId so this
         // route is maintained for that circumstance
@@ -59,7 +61,7 @@ export default class Commits extends Endpoint {
   ) {
     const { limit, startSha, endSha, ...requestOptions } = options;
 
-    return this.configureRequest<Promise<Commit[]>>({
+    return this.configureRequest<Promise<Commit[]>>("list", {
       api: async () => {
         const query = querystring.stringify({
           limit,

--- a/src/endpoints/Data.js
+++ b/src/endpoints/Data.js
@@ -8,6 +8,8 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 export default class Data extends Endpoint {
+  name = "data";
+
   async info(
     descriptor: LayerVersionDescriptor,
     requestOptions: RequestOptions = {}
@@ -16,7 +18,7 @@ export default class Data extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<LayerDataset>>({
+    return this.configureRequest<Promise<LayerDataset>>("info", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/commits/${latestDescriptor.sha}/files/${latestDescriptor.fileId}/layers/${latestDescriptor.layerId}/data`

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -37,7 +37,7 @@ export default class Endpoint {
     this.options = options;
   }
 
-  configureRequest<T>(name: string, config: RequestConfig<T>): T {
+  configureRequest<T>(requestName: string, config: RequestConfig<T>): T {
     const makeRequest = async () => {
       let response;
       const errors = {};
@@ -62,7 +62,7 @@ export default class Endpoint {
           const end = performance.now();
           if (this.options.analyticsCallback) {
             this.options.analyticsCallback({
-              type: `${this.name}#${name}`,
+              type: `${this.name}#${requestName}`,
               duration: end - start,
               transportMode: mode
             });
@@ -171,7 +171,7 @@ export default class Endpoint {
   }
 
   createCursor<T>(
-    name: string,
+    requestName: string,
     getConfig: (nextOffset?: number) => RequestConfig<any>,
     getValue: (response: any) => any
   ): T {
@@ -184,7 +184,7 @@ export default class Endpoint {
         }
 
         return this.configureRequest<any>(
-          name,
+          requestName,
           getConfig(response && response.meta.nextOffset)
         );
       });

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -62,8 +62,9 @@ export default class Endpoint {
           const end = performance.now();
           if (this.options.analyticsCallback) {
             this.options.analyticsCallback({
-              type: `${this.name}#${requestName}`,
               duration: end - start,
+              endpoint: this.name,
+              request: requestName,
               transportMode: mode
             });
           }

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -1,5 +1,5 @@
 /* @flow */
-/* global fetch */
+/* global fetch, performance */
 import { Readable } from "stream";
 import "cross-fetch/polyfill";
 import { spawn } from "child_process";
@@ -28,6 +28,7 @@ const logCLIResponse = log.extend("AbstractCLI:response");
 const minorVersion = version.split(".", 2).join(".");
 
 export default class Endpoint {
+  name: string;
   client: Client;
   options: CommandOptions;
 
@@ -36,7 +37,7 @@ export default class Endpoint {
     this.options = options;
   }
 
-  configureRequest<T>(config: RequestConfig<T>): T {
+  configureRequest<T>(name: string, config: RequestConfig<T>): T {
     const makeRequest = async () => {
       let response;
       const errors = {};
@@ -51,11 +52,21 @@ export default class Endpoint {
       for (const mode of transportMode) {
         let requestError;
         try {
-          if (!config[mode]) {
+          const request = config[mode];
+          if (!request) {
             throw new EndpointUndefinedError(mode);
           }
-          const operation = config[mode].call(this);
+          const start = performance.now();
+          const operation = request.call(this);
           response = await operation;
+          const end = performance.now();
+          if (this.options.analyticsCallback) {
+            this.options.analyticsCallback({
+              type: `${this.name}#${name}`,
+              duration: end - start,
+              transportMode: mode
+            });
+          }
         } catch (error) {
           requestError = error;
         }
@@ -160,6 +171,7 @@ export default class Endpoint {
   }
 
   createCursor<T>(
+    name: string,
     getConfig: (nextOffset?: number) => RequestConfig<any>,
     getValue: (response: any) => any
   ): T {
@@ -172,6 +184,7 @@ export default class Endpoint {
         }
 
         return this.configureRequest<any>(
+          name,
           getConfig(response && response.meta.nextOffset)
         );
       });

--- a/src/endpoints/Files.js
+++ b/src/endpoints/Files.js
@@ -15,12 +15,14 @@ const EXPORT_STATUS_CHECK_INTERVAL = 2000;
 const MAX_EXPORT_DURATION = EXPORT_STATUS_CHECK_INTERVAL * 15;
 
 export default class Files extends Endpoint {
+  name = "files";
+
   async info(descriptor: FileDescriptor, requestOptions: RequestOptions = {}) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );
 
-    return this.configureRequest<Promise<File>>({
+    return this.configureRequest<Promise<File>>("info", {
       api: async () => {
         const { fileId, ...branchDescriptor } = latestDescriptor;
         const files = await this.list(branchDescriptor);
@@ -55,7 +57,7 @@ export default class Files extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<File[]>>({
+    return this.configureRequest<Promise<File[]>>("list", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/files`
@@ -85,7 +87,7 @@ export default class Files extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<ArrayBuffer | void>>({
+    return this.configureRequest<Promise<ArrayBuffer | void>>("raw", {
       api: async () => {
         const exportRequest = (exportId?: string) => {
           return this.apiRequest(

--- a/src/endpoints/Layers.js
+++ b/src/endpoints/Layers.js
@@ -17,6 +17,8 @@ type LayersListOptions = {
 };
 
 export default class Layers extends Endpoint {
+  name = "layers";
+
   async info(
     descriptor: LayerVersionDescriptor,
     requestOptions: RequestOptions = {}
@@ -25,7 +27,7 @@ export default class Layers extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<Layer>>({
+    return this.configureRequest<Promise<Layer>>("info", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/commits/${latestDescriptor.sha}/files/${latestDescriptor.fileId}/layers/${latestDescriptor.layerId}`
@@ -60,7 +62,7 @@ export default class Layers extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<Layer[]>>({
+    return this.configureRequest<Promise<Layer[]>>("list", {
       api: async () => {
         const query = querystring.stringify({
           ...latestDescriptor,

--- a/src/endpoints/Memberships.js
+++ b/src/endpoints/Memberships.js
@@ -11,11 +11,13 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 export default class Memberships extends Endpoint {
+  name = "memberships";
+
   info(
     descriptor: OrganizationMembershipDescriptor | ProjectMembershipDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Membership>>({
+    return this.configureRequest<Promise<Membership>>("info", {
       api: async () => {
         let url = "";
 
@@ -38,7 +40,7 @@ export default class Memberships extends Endpoint {
     descriptor: OrganizationDescriptor | ProjectDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Membership[]>>({
+    return this.configureRequest<Promise<Membership[]>>("list", {
       api: async () => {
         let url = "";
 

--- a/src/endpoints/Notifications.js
+++ b/src/endpoints/Notifications.js
@@ -11,11 +11,13 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 export default class Notifications extends Endpoint {
+  name = "notifications";
+
   info(
     descriptor: NotificationDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Notification>>({
+    return this.configureRequest<Promise<Notification>>("info", {
       api: async () => {
         const response = await this.apiRequest(
           `notifications/${descriptor.notificationId}`
@@ -30,6 +32,7 @@ export default class Notifications extends Endpoint {
     const { limit, offset, ...requestOptions } = options;
 
     return this.createCursor<Promise<Notification[]>>(
+      "list",
       (nextOffset = offset) => ({
         api: () => {
           const query = querystring.stringify({

--- a/src/endpoints/Organizations.js
+++ b/src/endpoints/Organizations.js
@@ -8,11 +8,13 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 export default class Organizations extends Endpoint {
+  name = "organizations";
+
   info(
     descriptor: OrganizationDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Organization>>({
+    return this.configureRequest<Promise<Organization>>("info", {
       api: async () => {
         const response = await this.apiRequest(
           `organizations/${descriptor.organizationId}`
@@ -25,7 +27,7 @@ export default class Organizations extends Endpoint {
   }
 
   list(requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Organization[]>>({
+    return this.configureRequest<Promise<Organization[]>>("list", {
       api: async () => {
         const response = await this.apiRequest("organizations");
         return wrap(response.data, response);

--- a/src/endpoints/Pages.js
+++ b/src/endpoints/Pages.js
@@ -10,12 +10,14 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 export default class Pages extends Endpoint {
+  name = "pages";
+
   async info(descriptor: PageDescriptor, requestOptions: RequestOptions = {}) {
     const latestDescriptor = await this.client.descriptors.getLatestDescriptor(
       descriptor
     );
 
-    return this.configureRequest<Promise<Page>>({
+    return this.configureRequest<Promise<Page>>("info", {
       api: async () => {
         const { pageId, ...fileDescriptor } = latestDescriptor;
         const pages = await this.list(fileDescriptor);
@@ -45,7 +47,7 @@ export default class Pages extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<Page[]>>({
+    return this.configureRequest<Promise<Page[]>>("list", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${latestDescriptor.projectId}/branches/${latestDescriptor.branchId}/files/${latestDescriptor.fileId}/pages`

--- a/src/endpoints/Previews.js
+++ b/src/endpoints/Previews.js
@@ -12,6 +12,8 @@ import { isNodeEnvironment } from "../util/helpers";
 import Endpoint from "../endpoints/Endpoint";
 
 export default class Previews extends Endpoint {
+  name = "previews";
+
   async info(
     descriptor: LayerVersionDescriptor,
     requestOptions: RequestOptions = {}
@@ -20,7 +22,7 @@ export default class Previews extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<PreviewMeta>>({
+    return this.configureRequest<Promise<PreviewMeta>>("info", {
       api: async () => ({
         webUrl: `${await this.options.webUrl}/projects/${
           latestDescriptor.projectId
@@ -38,7 +40,7 @@ export default class Previews extends Endpoint {
       descriptor
     );
 
-    return this.configureRequest<Promise<ArrayBuffer>>({
+    return this.configureRequest<Promise<ArrayBuffer>>("raw", {
       api: async () => {
         const previewUrl = await this.options.previewUrl;
         const arrayBuffer = await this.apiRequest(

--- a/src/endpoints/Projects.js
+++ b/src/endpoints/Projects.js
@@ -15,8 +15,10 @@ const headers = {
 };
 
 export default class Projects extends Endpoint {
+  name = "projects";
+
   info(descriptor: ProjectDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Project>>({
+    return this.configureRequest<Promise<Project>>("info", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}`,
@@ -39,7 +41,7 @@ export default class Projects extends Endpoint {
   ) {
     const { filter, sectionId, ...requestOptions } = options;
 
-    return this.configureRequest<Promise<Project[]>>({
+    return this.configureRequest<Promise<Project[]>>("list", {
       api: async () => {
         const query = querystring.stringify({
           ...descriptor,
@@ -69,7 +71,7 @@ export default class Projects extends Endpoint {
   ) {
     project.about = (project: any).description;
 
-    return this.configureRequest<Promise<Project>>({
+    return this.configureRequest<Promise<Project>>("create", {
       api: async () => {
         const response = await this.apiRequest(`projects`, {
           method: "POST",
@@ -88,7 +90,7 @@ export default class Projects extends Endpoint {
   ) {
     project.about = (project: any).description;
 
-    return this.configureRequest<Promise<Project>>({
+    return this.configureRequest<Promise<Project>>("update", {
       api: async () => {
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}`,
@@ -104,7 +106,7 @@ export default class Projects extends Endpoint {
   }
 
   delete(descriptor: ProjectDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<void>>({
+    return this.configureRequest<Promise<void>>("delete", {
       api: () => {
         return this.apiRequest(`projects/${descriptor.projectId}`, {
           method: "DELETE"
@@ -115,7 +117,7 @@ export default class Projects extends Endpoint {
   }
 
   archive(descriptor: ProjectDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Project>>({
+    return this.configureRequest<Promise<Project>>("archive", {
       api: () => {
         return this.apiRequest(`projects/${descriptor.projectId}/archive`, {
           method: "PUT"
@@ -129,7 +131,7 @@ export default class Projects extends Endpoint {
     descriptor: ProjectDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Project>>({
+    return this.configureRequest<Promise<Project>>("unarchive", {
       api: () => {
         return this.apiRequest(`projects/${descriptor.projectId}/unarchive`, {
           method: "PUT"

--- a/src/endpoints/ReviewRequests.js
+++ b/src/endpoints/ReviewRequests.js
@@ -10,11 +10,13 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 export default class ReviewRequests extends Endpoint {
+  name = "reviewRequeasts";
+
   list(
     descriptor: OrganizationDescriptor | ProjectDescriptor | BranchDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<ReviewRequest[]>>({
+    return this.configureRequest<Promise<ReviewRequest[]>>("list", {
       api: async () => {
         let url = "";
 

--- a/src/endpoints/Sections.js
+++ b/src/endpoints/Sections.js
@@ -4,11 +4,13 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 export default class Sections extends Endpoint {
+  name = "sections";
+
   list(
     descriptor: OrganizationDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Section[]>>({
+    return this.configureRequest<Promise<Section[]>>("list", {
       api: async () => {
         const response = await this.apiRequest(
           `sections?organizationId=${descriptor.organizationId}`

--- a/src/endpoints/Shares.js
+++ b/src/endpoints/Shares.js
@@ -14,12 +14,14 @@ const headers = {
 };
 
 export default class Shares extends Endpoint {
+  name = "shares";
+
   create<T: Share>(
     descriptor: OrganizationDescriptor,
     shareInput: ShareInput,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<T>>({
+    return this.configureRequest<Promise<T>>("create", {
       api: async () => {
         const response = await this.apiRequest("share_links", {
           method: "POST",
@@ -40,7 +42,7 @@ export default class Shares extends Endpoint {
     descriptor: ShareDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<T>>({
+    return this.configureRequest<Promise<T>>("info", {
       api: async () => {
         const response = await this.apiRequest(
           `share_links/${inferShareId(descriptor)}`,

--- a/src/endpoints/Stars.js
+++ b/src/endpoints/Stars.js
@@ -9,8 +9,10 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 export default class Stars extends Endpoint {
+  name = "stars";
+
   list(requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Star[]>>({
+    return this.configureRequest<Promise<Star[]>>("list", {
       api: async () => {
         const response = await this.apiRequest("starred");
         return wrap(response);
@@ -27,7 +29,7 @@ export default class Stars extends Endpoint {
       descriptor.sectionId === undefined
         ? descriptor.projectId
         : descriptor.sectionId;
-    return this.configureRequest<Promise<Star>>({
+    return this.configureRequest<Promise<Star>>("create", {
       api: async () => {
         const response = await this.apiRequest(`starred/${starrableId}`, {
           method: "PUT"
@@ -46,7 +48,7 @@ export default class Stars extends Endpoint {
       descriptor.sectionId === undefined
         ? descriptor.projectId
         : descriptor.sectionId;
-    return this.configureRequest<Promise<void>>({
+    return this.configureRequest<Promise<void>>("delete", {
       api: () => {
         return this.apiRequest(`starred/${starrableId}`, { method: "DELETE" });
       },

--- a/src/endpoints/Users.js
+++ b/src/endpoints/Users.js
@@ -10,8 +10,10 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 export default class Users extends Endpoint {
+  name = "users";
+
   info(descriptor: UserDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<User>>({
+    return this.configureRequest<Promise<User>>("info", {
       api: async () => {
         const response = await this.apiRequest(`users/${descriptor.userId}`);
         return wrap(response);
@@ -24,7 +26,7 @@ export default class Users extends Endpoint {
     descriptor: OrganizationDescriptor | ProjectDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<User[]>>({
+    return this.configureRequest<Promise<User[]>>("list", {
       api: async () => {
         let url = "";
 

--- a/src/endpoints/Webhooks.js
+++ b/src/endpoints/Webhooks.js
@@ -14,11 +14,13 @@ import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
 export default class Users extends Endpoint {
+  name = "webhooks";
+
   list(
     descriptor: OrganizationDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Webhook[]>>({
+    return this.configureRequest<Promise<Webhook[]>>("list", {
       api: async () => {
         const response = await this.apiRequest(
           `organizations/${descriptor.organizationId}/webhooks`
@@ -30,7 +32,7 @@ export default class Users extends Endpoint {
   }
 
   info(descriptor: WebhookDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<Webhook>>({
+    return this.configureRequest<Promise<Webhook>>("info", {
       api: async () => {
         const response = await this.apiRequest(
           `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}`
@@ -45,7 +47,7 @@ export default class Users extends Endpoint {
     descriptor: OrganizationDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<WebhookEvent[]>>({
+    return this.configureRequest<Promise<WebhookEvent[]>>("events", {
       api: async () => {
         const response = await this.apiRequest(
           `organizations/${descriptor.organizationId}/webhooks/events`
@@ -61,7 +63,7 @@ export default class Users extends Endpoint {
     webhook: NewWebhook,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Webhook>>({
+    return this.configureRequest<Promise<Webhook>>("create", {
       api: async () => {
         const response = await this.apiRequest(
           `organizations/${descriptor.organizationId}/webhooks/subscribe`,
@@ -83,7 +85,7 @@ export default class Users extends Endpoint {
     webhook: Webhook,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<Webhook>>({
+    return this.configureRequest<Promise<Webhook>>("update", {
       api: async () => {
         const response = await this.apiRequest(
           `organizations/${descriptor.organizationId}/webhooks/subscribe`,
@@ -101,7 +103,7 @@ export default class Users extends Endpoint {
   }
 
   delete(descriptor: WebhookDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<void>>({
+    return this.configureRequest<Promise<void>>("delete", {
       api: () => {
         return this.apiRequest(
           `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}/unsubscribe`,
@@ -113,7 +115,7 @@ export default class Users extends Endpoint {
   }
 
   ping(descriptor: WebhookDescriptor, requestOptions: RequestOptions = {}) {
-    return this.configureRequest<Promise<void>>({
+    return this.configureRequest<Promise<void>>("ping", {
       api: () => {
         return this.apiRequest(
           `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}/ping`,
@@ -128,7 +130,7 @@ export default class Users extends Endpoint {
     descriptor: WebhookDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<WebhookDelivery[]>>({
+    return this.configureRequest<Promise<WebhookDelivery[]>>("deliveries", {
       api: async () => {
         const response = await this.apiRequest(
           `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}/deliveries`
@@ -143,7 +145,7 @@ export default class Users extends Endpoint {
     descriptor: WebhookDeliveryDescriptor,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<void>>({
+    return this.configureRequest<Promise<void>>("redeliver", {
       api: () => {
         return this.apiRequest(
           `organizations/${descriptor.organizationId}/webhooks/${descriptor.webhookId}/deliveries/${descriptor.deliveryId}/redeliver`,
@@ -160,7 +162,7 @@ export default class Users extends Endpoint {
     signingKey: string,
     requestOptions: RequestOptions = {}
   ) {
-    return this.configureRequest<Promise<boolean>>({
+    return this.configureRequest<Promise<boolean>>("verify", {
       api: async () => {
         const signature = sha256.hmac(signingKey, JSON.stringify(payload));
         return signature === expectedSignature;

--- a/src/types.js
+++ b/src/types.js
@@ -143,8 +143,15 @@ export type AccessTokenOption =
   | (() => AccessToken) // TODO: Deprecate
   | (() => Promise<AccessToken>);
 
+export type EndpointAnalytic = {
+  type: string,
+  duration: number,
+  transportMode: "api" | "cli"
+};
+
 export type CommandOptions = {
   accessToken: AccessTokenOption,
+  analyticsCallback: EndpointAnalytic => mixed,
   apiUrl: string | Promise<string>,
   objectUrl: string | Promise<string>,
   previewUrl: string | Promise<string>,

--- a/src/types.js
+++ b/src/types.js
@@ -144,8 +144,9 @@ export type AccessTokenOption =
   | (() => Promise<AccessToken>);
 
 export type EndpointAnalytic = {
-  type: string,
   duration: number,
+  endpoint: string,
+  request: string,
   transportMode: "api" | "cli"
 };
 

--- a/src/types.js
+++ b/src/types.js
@@ -143,7 +143,7 @@ export type AccessTokenOption =
   | (() => AccessToken) // TODO: Deprecate
   | (() => Promise<AccessToken>);
 
-export type EndpointAnalytic = {
+export type EndpointMetric = {
   duration: number,
   endpoint: string,
   request: string,
@@ -152,7 +152,7 @@ export type EndpointAnalytic = {
 
 export type CommandOptions = {
   accessToken: AccessTokenOption,
-  analyticsCallback: EndpointAnalytic => mixed,
+  analyticsCallback: EndpointMetric => mixed,
   apiUrl: string | Promise<string>,
   objectUrl: string | Promise<string>,
   previewUrl: string | Promise<string>,

--- a/tests/endpoints/Activities.test.js
+++ b/tests/endpoints/Activities.test.js
@@ -1,6 +1,5 @@
 // @flow
-import { mockAPI, API_CLIENT, CLIENT_CONFIG } from "../../src/util/testing";
-import Client from "../../src/Client";
+import { mockAPI, API_CLIENT } from "../../src/util/testing";
 
 describe("activities", () => {
   describe("info", () => {
@@ -16,28 +15,6 @@ describe("activities", () => {
       expect(response).toEqual({
         id: "activity-id"
       });
-    });
-
-    test("analytics", async () => {
-      let analyticsResult;
-
-      const client = new Client({
-        ...CLIENT_CONFIG,
-        analyticsCallback: analytics => (analyticsResult = analytics)
-      });
-      mockAPI("/activities/activity-id", {
-        id: "activity-id"
-      });
-
-      await client.activities.info({
-        activityId: "activity-id"
-      });
-
-      if (!analyticsResult) {
-        throw new Error("analytics should be defined");
-      }
-      expect(analyticsResult.type).toEqual("activities#info");
-      expect(analyticsResult.transportMode).toEqual("api");
     });
   });
 

--- a/tests/endpoints/Activities.test.js
+++ b/tests/endpoints/Activities.test.js
@@ -1,5 +1,6 @@
 // @flow
-import { mockAPI, API_CLIENT } from "../../src/util/testing";
+import { mockAPI, API_CLIENT, CLIENT_CONFIG } from "../../src/util/testing";
+import Client from "../../src/Client";
 
 describe("activities", () => {
   describe("info", () => {
@@ -15,6 +16,28 @@ describe("activities", () => {
       expect(response).toEqual({
         id: "activity-id"
       });
+    });
+
+    test("analytics", async () => {
+      let analyticsResult;
+
+      const client = new Client({
+        ...CLIENT_CONFIG,
+        analyticsCallback: analytics => (analyticsResult = analytics)
+      });
+      mockAPI("/activities/activity-id", {
+        id: "activity-id"
+      });
+
+      await client.activities.info({
+        activityId: "activity-id"
+      });
+
+      if (!analyticsResult) {
+        throw new Error("analytics should be defined");
+      }
+      expect(analyticsResult.type).toEqual("activities#info");
+      expect(analyticsResult.transportMode).toEqual("api");
     });
   });
 

--- a/tests/endpoints/Endpoint.test.js
+++ b/tests/endpoints/Endpoint.test.js
@@ -2,7 +2,7 @@
 import { CLIENT_CONFIG } from "../../src/util/testing";
 import Client from "../../src/Client";
 import Endpoint from "../../src/endpoints/Endpoint";
-import type { EndpointAnalytic } from "../../src/types";
+import type { EndpointMetric } from "../../src/types";
 
 function sleep(ms: number) {
   return new Promise(resolve => {
@@ -28,7 +28,7 @@ class ExampleEndpoint extends Endpoint {
 describe("endpoint", () => {
   describe("analyticsCallback", () => {
     test("api", async () => {
-      let analyticsResult: ?EndpointAnalytic;
+      let analyticsResult: ?EndpointMetric;
       const options = {
         ...CLIENT_CONFIG,
         analyticsCallback: analytics => (analyticsResult = analytics)
@@ -53,7 +53,7 @@ describe("endpoint", () => {
     });
 
     test("cli", async () => {
-      let analyticsResult: ?EndpointAnalytic;
+      let analyticsResult: ?EndpointMetric;
       const options = {
         ...CLIENT_CONFIG,
         analyticsCallback: analytics => (analyticsResult = analytics)

--- a/tests/endpoints/Endpoint.test.js
+++ b/tests/endpoints/Endpoint.test.js
@@ -1,0 +1,80 @@
+// @flow
+import { CLIENT_CONFIG } from "../../src/util/testing";
+import Client from "../../src/Client";
+import Endpoint from "../../src/endpoints/Endpoint";
+import type { EndpointAnalytic } from "../../src/types";
+
+function sleep(ms: number) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+class ExampleEndpoint extends Endpoint {
+  name = "exampleEndpoint";
+
+  info() {
+    return this.configureRequest<Promise<void>>("info", {
+      api() {
+        return sleep(1);
+      },
+      cli() {
+        return sleep(1);
+      }
+    });
+  }
+}
+
+describe("endpoint", () => {
+  describe("analyticsCallback", () => {
+    test("api", async () => {
+      let analyticsResult: ?EndpointAnalytic;
+      const options = {
+        ...CLIENT_CONFIG,
+        analyticsCallback: analytics => (analyticsResult = analytics)
+      };
+
+      const client = new Client(options);
+      const endpoint = new ExampleEndpoint(client, {
+        ...options,
+        transportMode: ["api"],
+        webUrl: "https://example.com"
+      });
+
+      await endpoint.info();
+
+      if (!analyticsResult) {
+        throw new Error("analytics should be defined");
+      }
+      expect(analyticsResult.duration).toBeGreaterThan(0);
+      expect(analyticsResult.endpoint).toEqual("exampleEndpoint");
+      expect(analyticsResult.request).toEqual("info");
+      expect(analyticsResult.transportMode).toEqual("api");
+    });
+
+    test("cli", async () => {
+      let analyticsResult: ?EndpointAnalytic;
+      const options = {
+        ...CLIENT_CONFIG,
+        analyticsCallback: analytics => (analyticsResult = analytics)
+      };
+
+      const client = new Client(options);
+      const endpoint = new ExampleEndpoint(client, {
+        ...options,
+        transportMode: ["cli"],
+        webUrl: "https://example.com"
+      });
+
+      await endpoint.info();
+
+      if (!analyticsResult) {
+        throw new Error("analytics should be defined");
+      }
+      expect(analyticsResult.duration).toBeGreaterThan(0);
+      expect(analyticsResult.endpoint).toEqual("exampleEndpoint");
+      expect(analyticsResult.request).toEqual("info");
+      expect(analyticsResult.transportMode).toEqual("cli");
+    });
+  });
+});


### PR DESCRIPTION
Adds a callback option to `Client` so you can receive data about each endpoint called in the sdk which will enable us to compare execution times for api vs. cli requests for quick sync:

<img width="652" alt="image" src="https://user-images.githubusercontent.com/216355/77487638-3828d480-6df0-11ea-95c7-f7825ea47f18.png">

I'll leave some comments inline.
Part of https://goabstract.atlassian.net/browse/PLATFORM-1029

