### PR TITLE
fix: Prefer "files list" over deprecated "files".

### DIFF
--- a/src/endpoints/Pages.js
+++ b/src/endpoints/Pages.js
@@ -59,8 +59,9 @@ export default class Pages extends Endpoint {
       cli: async () => {
         const response = await this.cliRequest([
           "files",
-          latestDescriptor.projectId,
-          latestDescriptor.sha
+          "list",
+          `--project-id=${latestDescriptor.projectId}`,
+          `--sha=${latestDescriptor.sha}`
         ]);
 
         return wrap(response.pages, response);

--- a/tests/endpoints/Pages.test.js
+++ b/tests/endpoints/Pages.test.js
@@ -54,7 +54,7 @@ describe("pages", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["files", "project-id", "sha"], {
+      mockCLI(["files", "list", "--project-id=project-id", "--sha=sha"], {
         pages: [
           {
             id: "page-id"
@@ -76,7 +76,7 @@ describe("pages", () => {
     });
 
     test("cli - not found", async () => {
-      mockCLI(["files", "project-id", "sha"], {
+      mockCLI(["files", "list", "--project-id=project-id", "--sha=sha"], {
         pages: [
           {
             id: "not-found"
@@ -123,7 +123,7 @@ describe("pages", () => {
     });
 
     test("cli", async () => {
-      mockCLI(["files", "project-id", "sha"], {
+      mockCLI(["files", "list", "--project-id=project-id", "--sha=sha"], {
         pages: [
           {
             id: "page-id"


### PR DESCRIPTION
Switch to using `abstract-cli files list` to get the pages instead of `abstract-cli files`.