### PR TITLE
feat: allow analytics callback to be set on Client

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -1833,10 +1833,12 @@ type EndpointMetric = {
   transportMode: "api" | "cli"
 };
 
+type AnalyticsCallback = (metric: EndpointMetric) => any
+
 type CommandOptions = {
   accessToken: AccessTokenOption,
   apiUrl: string | Promise<string>,
-  analyticsCallback: (analytics: EndpointMetric) => any,
+  analyticsCallback: AnalyticsCallback,
   assetUrl: string | Promise<string>,
   previewUrl: string | Promise<string>,
   transportMode: ("api" | "cli")[],

--- a/src/Client.js
+++ b/src/Client.js
@@ -51,7 +51,7 @@ export default class Client {
   users: Users;
   webhooks: Webhooks;
 
-  analyticsCallback: ?AnalyticsCallback;
+  _analyticsCallback: ?AnalyticsCallback;
 
   constructor(options: $Shape<CommandOptions> = {}) {
     options = {
@@ -65,7 +65,7 @@ export default class Client {
       ...options
     };
 
-    this.analyticsCallback = options.analyticsCallback;
+    this._analyticsCallback = options.analyticsCallback;
     this.activities = new Activities(this, options);
     this.assets = new Assets(this, options);
     this.branches = new Branches(this, options);

--- a/src/Client.js
+++ b/src/Client.js
@@ -23,7 +23,7 @@ import Shares from "./endpoints/Shares";
 import Stars from "./endpoints/Stars";
 import Users from "./endpoints/Users";
 import Webhooks from "./endpoints/Webhooks";
-import type { CommandOptions } from "./types";
+import type { CommandOptions, AnalyticsCallback } from "./types";
 
 export default class Client {
   activities: Activities;
@@ -51,6 +51,8 @@ export default class Client {
   users: Users;
   webhooks: Webhooks;
 
+  analyticsCallback: ?AnalyticsCallback;
+
   constructor(options: $Shape<CommandOptions> = {}) {
     options = {
       accessToken: process.env.ABSTRACT_TOKEN,
@@ -63,6 +65,7 @@ export default class Client {
       ...options
     };
 
+    this.analyticsCallback = options.analyticsCallback;
     this.activities = new Activities(this, options);
     this.assets = new Assets(this, options);
     this.branches = new Branches(this, options);

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -60,8 +60,8 @@ export default class Endpoint {
           const operation = request.call(this);
           response = await operation;
           const end = performance.now();
-          if (this.options.analyticsCallback) {
-            this.options.analyticsCallback({
+          if (this.client.analyticsCallback) {
+            this.client.analyticsCallback({
               duration: end - start,
               endpoint: this.name,
               request: requestName,

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -60,8 +60,8 @@ export default class Endpoint {
           const operation = request.call(this);
           response = await operation;
           const end = performance.now();
-          if (this.client.analyticsCallback) {
-            this.client.analyticsCallback({
+          if (this.client._analyticsCallback) {
+            this.client._analyticsCallback({
               duration: end - start,
               endpoint: this.name,
               request: requestName,

--- a/src/types.js
+++ b/src/types.js
@@ -150,9 +150,11 @@ export type EndpointMetric = {
   transportMode: "api" | "cli"
 };
 
+export type AnalyticsCallback = EndpointMetric => mixed;
+
 export type CommandOptions = {
   accessToken: AccessTokenOption,
-  analyticsCallback: EndpointMetric => mixed,
+  analyticsCallback: AnalyticsCallback,
   apiUrl: string | Promise<string>,
   objectUrl: string | Promise<string>,
   previewUrl: string | Promise<string>,


### PR DESCRIPTION
This is a follow-up to https://github.com/goabstract/abstract-sdk/pull/242. We have a need to be able to set the analytics callback separately between desktop and web, so we need to be able to set it outside of the constructor. This PR maintains the same ability to pass it as part of the constructor, but also be able to set the callback directly on `Client`.