### PR TITLE
fix: Add perfomance from  perf_hooks (Node v8.5.0+)

### DIFF
--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -3,6 +3,8 @@
 import { Readable } from "stream";
 import "cross-fetch/polyfill";
 import { spawn } from "child_process";
+// $FlowFixMe
+import { performance } from "perf_hooks";
 import uuid from "uuid/v4";
 import { version } from "../../package.json";
 import Client from "../Client";

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -3,8 +3,6 @@
 import { Readable } from "stream";
 import "cross-fetch/polyfill";
 import { spawn } from "child_process";
-// $FlowFixMe
-import { performance } from "perf_hooks";
 import uuid from "uuid/v4";
 import { version } from "../../package.json";
 import Client from "../Client";
@@ -58,12 +56,19 @@ export default class Endpoint {
           if (!request) {
             throw new EndpointUndefinedError(mode);
           }
-          const start = performance.now();
+
+          let start: number;
+          const { _analyticsCallback } = this.client;
+          if (performance && _analyticsCallback) {
+            start = performance.now();
+          }
+
           const operation = request.call(this);
           response = await operation;
-          const end = performance.now();
-          if (this.client._analyticsCallback) {
-            this.client._analyticsCallback({
+
+          if (start && performance && _analyticsCallback) {
+            const end = performance.now();
+            _analyticsCallback({
               duration: end - start,
               endpoint: this.name,
               request: requestName,


### PR DESCRIPTION
Fixes the error from `8.0.0-beta.20` regarding:

```
api: ReferenceError: performance is not defined
at makeRequest (project/node_modules/abstract-sdk/dist/endpoints/Endpoint.js:79:25)
```