### PR TITLE
fix: only use performance.now when it is available

### DIFF
--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -3,8 +3,6 @@
 import { Readable } from "stream";
 import "cross-fetch/polyfill";
 import { spawn } from "child_process";
-// $FlowFixMe
-import { performance } from "perf_hooks";
 import uuid from "uuid/v4";
 import { version } from "../../package.json";
 import Client from "../Client";
@@ -58,12 +56,19 @@ export default class Endpoint {
           if (!request) {
             throw new EndpointUndefinedError(mode);
           }
-          const start = performance.now();
+
+          let start: number;
+          const { _analyticsCallback } = this.client;
+          if (performance && _analyticsCallback) {
+            start = performance.now();
+          }
+
           const operation = request.call(this);
           response = await operation;
-          const end = performance.now();
-          if (this.client._analyticsCallback) {
-            this.client._analyticsCallback({
+
+          if (start && performance && _analyticsCallback) {
+            const end = performance.now();
+            _analyticsCallback({
               duration: end - start,
               endpoint: this.name,
               request: requestName,


### PR DESCRIPTION
Proposing an alternate solution to https://github.com/goabstract/abstract-sdk/pull/251, since we're not sure if node's `perf_tools` module is going to work in the browser. We know that this will give us what we need for the internal analytics reporting, and doing it this way won't break for node users. If we need to make this public in the future, we can find a way to use either `perf_tools` or `window.performance` depending on whether the consumer is a browser or a node environment, but I think this is probably what we need for now.