### PR TITLE
chore(docs) symbolId is UUID to symbol master

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -779,7 +779,7 @@ abstract.commits.info({
 | `libraryName` | `string`          | The name of the library file this layer is from |
 | `parentId`    | `string`          | UUID of the parent layer, if any                |
 | `properties`  | `LayerProperties` | Layer properties (to be documented)             |
-| `symbolId`    | `string`          | UUID of the parent symbol, if any               |
+| `symbolId`    | `string`          | UUID of symbol master, if any                   |
 | `type`        | `string`          | One of `artboard`, `layer`, `symbolMaster`, `symbolInstance`, `group`, `text`, `bitmap`, `shapeGroup`, `shapePath`, `rectangle`, `oval`, `polygon`, `triangle`, `star`, `page`, `slice`, `hotspot` |
 
 


### PR DESCRIPTION
- `symbolId` is a UUID to symbol master
- `symbolId` is defined on layers when type: `symbolInstance` and `symbolMaster`
- `symbolId` on a symbol master is self-referential
