### PR TITLE
chore(docs): Remove optional sha from LayerDescriptor

### DIFF
--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -2044,8 +2044,7 @@ Reference for the parameters required to load resources with the Abstract SDK.
   projectId: string,
   branchId: string | "master",
   fileId: string,
-  layerId: string,
-  sha?: string | "latest"
+  layerId: string
 }
 ```
 


### PR DESCRIPTION
Another little doc issue I noticed today. If you have a  `LayerDescriptor` with a `sha` you have a `LayerVersionDescriptor`

