### PR TITLE
chore: use api version 25 for collection lists

### DIFF
--- a/src/endpoints/Collections.js
+++ b/src/endpoints/Collections.js
@@ -112,7 +112,7 @@ export default class Collections extends Endpoint {
           `projects/${projectId}/collections?${query}`,
           {
             headers: {
-              "Abstract-Api-Version": requestOptions._version || API_VERSION
+              "Abstract-Api-Version": requestOptions._version || 25 // 25 includes `branches` as part of the response
             }
           }
         );


### PR DESCRIPTION
The API including `branches` as part of the `collections#index` response is being put behind an API version (https://github.com/goabstract/projects/pull/4521). This PR bumps the API version for that call to the API.