### PR TITLE
fix: 'active' filter with latest CLI only filters to specifically active branches

### DIFF
--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -71,11 +71,16 @@ export default class Branches extends Endpoint {
         if (!descriptor) {
           throw new BranchSearchCLIError();
         }
+
+        let normalizedFilter = filter;
+        if (filter === "active") {
+          normalizedFilter = "workedOn";
+        }
         const response = await this.cliRequest([
           "branches",
           "list",
           `--project-id=${descriptor.projectId}`,
-          ...(filter ? ["--filter", filter] : [])
+          ...(normalizedFilter ? ["--filter", normalizedFilter] : [])
         ]);
 
         return wrap(response.branches, response);

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -159,7 +159,7 @@ describe("branches", () => {
 
     test("cli - filter", async () => {
       mockCLI(
-        ["branches", "list", "--project-id=project-id", "--filter", "mine"],
+        ["branches", "list", "--project-id=project-id", "--filter", "workedOn"],
         {
           branches: [
             {
@@ -174,7 +174,7 @@ describe("branches", () => {
           projectId: "project-id"
         },
         {
-          filter: "mine"
+          filter: "active"
         }
       );
 


### PR DESCRIPTION
In the below PR "active" was replaced with "workedOn" for the CLI only. Because we still use "active" with the API the SDK seems to be the correct place to normalize this.

reference: https://github.com/goabstract/projects/pull/4013