### PR TITLE
fix: Optional Error.captureStackTrace

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -10,6 +10,7 @@ export class BaseError extends Error {
     super(message);
     this.name = this.constructor.name;
 
+    /* istanbul ignore next */
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor); // This is a Node API that helps stack trace readability
     }

--- a/src/errors.js
+++ b/src/errors.js
@@ -9,7 +9,10 @@ export class BaseError extends Error {
   constructor(message: string) {
     super(message);
     this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
+    
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
   }
 }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -10,7 +10,7 @@ export class BaseError extends Error {
     super(message);
     this.name = this.constructor.name;
 
-    if (Error.captureStackTrace) { 
+    if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor); // This is a Node API that helps stack trace readability
     }
   }

--- a/src/errors.js
+++ b/src/errors.js
@@ -10,8 +10,8 @@ export class BaseError extends Error {
     super(message);
     this.name = this.constructor.name;
 
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
+    if (Error.captureStackTrace) { 
+      Error.captureStackTrace(this, this.constructor); // This is a Node API that helps stack trace readability
     }
   }
 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -9,7 +9,7 @@ export class BaseError extends Error {
   constructor(message: string) {
     super(message);
     this.name = this.constructor.name;
-    
+
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);
     }


### PR DESCRIPTION
- Do not try to capture stack trace when `Error.captureStackTrace` is not available

Fixes https://sentry.io/organizations/elastic-projects/issues/1633606217/?project=103885