### PR TITLE
chore: bump collections api to 26

### DIFF
--- a/src/endpoints/Collections.js
+++ b/src/endpoints/Collections.js
@@ -112,7 +112,7 @@ export default class Collections extends Endpoint {
           `projects/${projectId}/collections?${query}`,
           {
             headers: {
-              "Abstract-Api-Version": requestOptions._version || 25 // 25 includes `branches` as part of the response
+              "Abstract-Api-Version": requestOptions._version || 26 // 26 includes `branches` as part of the response
             }
           }
         );


### PR DESCRIPTION
Bumping the collections api to 26. This will likely need to be coordinated alongside release 92.

Reference: https://github.com/goabstract/ui/pull/2939