### PR TITLE
refactor: moves url param to ShareUrlDescriptor

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -422,7 +422,9 @@ type LayerDescriptor = {
   layerId: string
 };
 
-type ShareDescriptor = { url: string } | { shareId: string };
+type ShareDescriptor = { shareId: string };
+
+type ShareUrlDescriptor =  { url: string };
 
 type UserDescriptor = {
   userId: string

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -2267,7 +2267,13 @@ Reference for the parameters required to load resources with the Abstract SDK.
 ### ShareDescriptor
 
 ```js
-{ url: string } | { shareId: string }
+{ shareId: string }
+```
+
+### ShareUrlDescriptor
+
+```js
+{ url: string }
 ```
 
 ### BranchDescriptor

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -1834,7 +1834,7 @@ A share is a shareable url to an object in Abstract. You can use the desktop or 
 
 ![API][api-icon]
 
-`shares.info(ShareDescriptor, RequestOptions): Promise<Share>`
+`shares.info(ShareDescriptor | ShareUrlDescriptor, RequestOptions): Promise<Share>`
 
 ```js
 abstract.shares.info({
@@ -1854,12 +1854,12 @@ abstract.shares.info({
 
 ![API][api-icon]
 
-`shares.info(ShareDescriptor, RequestOptions): Promise<Share>`
+`shares.info(ShareDescriptor | ShareUrlDescriptor, RequestOptions): Promise<Share>`
 
 List all files for branch's share url
 
 ```js
-const branchShare = await abstract.share.info({
+const branchShare = await abstract.shares.info({
   url: 'https://share.goabstract.com/49b1f582-a8b4-46ca-8c86-bbc675fe27c4'
 })
 

--- a/src/endpoints/Shares.js
+++ b/src/endpoints/Shares.js
@@ -5,6 +5,7 @@ import type {
   RequestOptions,
   Share,
   ShareDescriptor,
+  ShareUrlDescriptor,
   ShareInput
 } from "../types";
 import Endpoint from "../endpoints/Endpoint";
@@ -39,7 +40,7 @@ export default class Shares extends Endpoint {
   }
 
   info<T: Share>(
-    descriptor: ShareDescriptor,
+    descriptor: ShareDescriptor | ShareUrlDescriptor,
     requestOptions: RequestOptions = {}
   ) {
     return this.configureRequest<Promise<T>>("info", {

--- a/src/types.js
+++ b/src/types.js
@@ -139,7 +139,7 @@ export type CollectionsListOptions = {
   userId?: string
 };
 
-export type AccessToken = ?string | ShareDescriptor;
+export type AccessToken = ?string | ShareDescriptor | ShareUrlDescriptor;
 export type AccessTokenOption =
   | AccessToken // TODO: Deprecate?
   | (() => AccessToken) // TODO: Deprecate

--- a/src/types.js
+++ b/src/types.js
@@ -77,7 +77,9 @@ export type LayerVersionDescriptor = {|
   layerId: string
 |};
 
-export type ShareDescriptor = {| url: string |} | {| shareId: string |};
+export type ShareDescriptor = {| shareId: string |};
+
+export type ShareUrlDescriptor = {| url: string |};
 
 export type ErrorData = {|
   path: string,

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -1,11 +1,13 @@
 // @flow
-import type { ShareDescriptor } from "../types";
+import type { ShareDescriptor, ShareUrlDescriptor } from "../types";
 
 function parseShareURL(url: string): ?string {
   return url.split(/share\.(?:go)?abstract\.com\//)[1];
 }
 
-export function inferShareId(shareDescriptor: ShareDescriptor): string {
+export function inferShareId(
+  shareDescriptor: ShareDescriptor | ShareUrlDescriptor
+): string {
   let shareId;
 
   if (shareDescriptor.url) {


### PR DESCRIPTION
In order to access the `shareId` prop in the `ui` project, we need to remove its union to `{| url: string |}` in the `ShareDescriptor` type. The url part was moved to a brand new `ShareUrlDescriptor`.

Will be updating accordingly the `ui` project right after this gets approved starting with this [PR](https://github.com/goabstract/ui/pull/2985).