### PR TITLE
feat: Add ability to set a shareId

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -1832,11 +1832,14 @@ interface CursorPromise<T> extends Promise<T> {
   next(): CursorPromise<T>;
 }
 
-type AccessToken = string | ShareDescriptor;
+type AccessToken = string;
 type AccessTokenOption =
   | AccessToken // TODO: Deprecate?
   | (() => AccessToken) // TODO: Deprecate
   | (() => Promise<AccessToken>);
+
+type ShareIdentifier = string | ShareDescriptor;
+type ShareIdOption = () => Promise<ShareIdentifier>;
 
 type EndpointMetric = {
   duration: number,
@@ -1848,11 +1851,12 @@ type EndpointMetric = {
 type AnalyticsCallback = (metric: EndpointMetric) => any
 
 type CommandOptions = {
-  accessToken: AccessTokenOption,
+  accessToken?: AccessTokenOption,
   apiUrl: string | Promise<string>,
   analyticsCallback: AnalyticsCallback,
   assetUrl: string | Promise<string>,
   previewUrl: string | Promise<string>,
+  shareId?: ShareIdOption,
   transportMode: ("api" | "cli")[],
   webUrl: string | Promise<string>
 };

--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -1838,8 +1838,7 @@ type AccessTokenOption =
   | (() => AccessToken) // TODO: Deprecate
   | (() => Promise<AccessToken>);
 
-type ShareIdentifier = string | ShareDescriptor;
-type ShareIdOption = () => Promise<ShareIdentifier>;
+type ShareIdOption = () => Promise<string | ShareDescriptor>;
 
 type EndpointMetric = {
   duration: number,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,10 @@ _Default value: `https://previews.goabstract.com`_
 
 This option can be used to specify a custom URL that points to an instance of the Abstract preview service. This is used when building preview image URLs used by the [API transport](/docs/transports). This option is useful if HTTP requests should be routed locally or through a proxy server.
 
+### `shareId`
+
+This option can be used to pass a share identifier (`string`, [`ShareDescriptor`](/docs/abstract-api/#sharedescriptor), or [`ShareUrlDescriptor`](/docs/abstract-api/#shareurldescriptor)) to access objects associated with a public [share](/docs/abstract-api/#shares) without having to authenticate with an `accessToken`.
+
 ### `transportMode`
 
 _Default value: `["api"]`_

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -265,6 +265,17 @@ export default class Endpoint {
         ? { Authorization: `Bearer ${token}` }
         : { "Abstract-Share-Id": token && inferShareId(token) };
 
+    let shareHeader;
+    const shareToken = this.options.shareToken
+      ? await this.options.shareToken()
+      : undefined;
+    if (shareToken) {
+      shareHeader = {
+        "Abstract-Share-Id":
+          typeof shareToken === "string" ? shareToken : inferShareId(shareToken)
+      };
+    }
+
     const headers = {
       Accept: "application/json",
       "Content-Type": "application/json",
@@ -272,6 +283,7 @@ export default class Endpoint {
       "X-Amzn-Trace-Id": `Root=1-${new Date().getTime()}-${uuid()}`,
       "Abstract-Api-Version": "8",
       ...tokenHeader,
+      ...shareHeader,
       ...customHeaders
     };
 

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -259,11 +259,11 @@ export default class Endpoint {
   }
 
   async _getFetchHeaders(customHeaders?: { [key: string]: string }) {
-    const token = await this._getAccessToken();
-    const tokenHeader =
-      typeof token === "string"
-        ? { Authorization: `Bearer ${token}` }
-        : { "Abstract-Share-Id": token && inferShareId(token) };
+    let accessTokenHeader;
+    const accessToken = await this._getAccessToken();
+    if (accessToken) {
+      accessTokenHeader = { Authorization: `Bearer ${accessToken}` };
+    }
 
     let shareIdHeader;
     const shareId = this.options.shareId
@@ -282,7 +282,7 @@ export default class Endpoint {
       "User-Agent": `Abstract SDK ${minorVersion}`,
       "X-Amzn-Trace-Id": `Root=1-${new Date().getTime()}-${uuid()}`,
       "Abstract-Api-Version": "8",
-      ...tokenHeader,
+      ...accessTokenHeader,
       ...shareIdHeader,
       ...customHeaders
     };

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -259,10 +259,10 @@ export default class Endpoint {
   }
 
   async _getFetchHeaders(customHeaders?: { [key: string]: string }) {
-    let accessTokenHeader;
+    let authorizationHeader;
     const accessToken = await this._getAccessToken();
     if (accessToken) {
-      accessTokenHeader = { Authorization: `Bearer ${accessToken}` };
+      authorizationHeader = { Authorization: `Bearer ${accessToken}` };
     }
 
     let shareIdHeader;
@@ -282,7 +282,7 @@ export default class Endpoint {
       "User-Agent": `Abstract SDK ${minorVersion}`,
       "X-Amzn-Trace-Id": `Root=1-${new Date().getTime()}-${uuid()}`,
       "Abstract-Api-Version": "8",
-      ...accessTokenHeader,
+      ...authorizationHeader,
       ...shareIdHeader,
       ...customHeaders
     };

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -265,14 +265,14 @@ export default class Endpoint {
         ? { Authorization: `Bearer ${token}` }
         : { "Abstract-Share-Id": token && inferShareId(token) };
 
-    let shareHeader;
-    const shareToken = this.options.shareToken
-      ? await this.options.shareToken()
+    let shareIdHeader;
+    const shareId = this.options.shareId
+      ? await this.options.shareId()
       : undefined;
-    if (shareToken) {
-      shareHeader = {
+    if (shareId) {
+      shareIdHeader = {
         "Abstract-Share-Id":
-          typeof shareToken === "string" ? shareToken : inferShareId(shareToken)
+          typeof shareId === "string" ? shareId : inferShareId(shareId)
       };
     }
 
@@ -283,7 +283,7 @@ export default class Endpoint {
       "X-Amzn-Trace-Id": `Root=1-${new Date().getTime()}-${uuid()}`,
       "Abstract-Api-Version": "8",
       ...tokenHeader,
-      ...shareHeader,
+      ...shareIdHeader,
       ...customHeaders
     };
 

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -259,22 +259,20 @@ export default class Endpoint {
   }
 
   async _getFetchHeaders(customHeaders?: { [key: string]: string }) {
-    let authorizationHeader;
     const accessToken = await this._getAccessToken();
-    if (accessToken) {
-      authorizationHeader = { Authorization: `Bearer ${accessToken}` };
-    }
+    const authorizationHeader = accessToken
+      ? { Authorization: `Bearer ${accessToken}` }
+      : undefined;
 
-    let shareIdHeader;
     const shareId = this.options.shareId
       ? await this.options.shareId()
       : undefined;
-    if (shareId) {
-      shareIdHeader = {
-        "Abstract-Share-Id":
-          typeof shareId === "string" ? shareId : inferShareId(shareId)
-      };
-    }
+    const shareIdHeader = shareId
+      ? {
+          "Abstract-Share-Id":
+            typeof shareId === "string" ? shareId : inferShareId(shareId)
+        }
+      : undefined;
 
     const headers = {
       Accept: "application/json",

--- a/src/types.js
+++ b/src/types.js
@@ -146,11 +146,6 @@ export type AccessTokenOption =
 export type ShareIdentifier = ?string | ShareDescriptor;
 export type ShareIdOption = () => Promise<ShareIdentifier>;
 
-type AuthenticationOptions = {
-  accessToken?: AccessTokenOption,
-  shareId?: ShareIdOption
-};
-
 export type EndpointMetric = {
   duration: number,
   endpoint: string,
@@ -161,11 +156,12 @@ export type EndpointMetric = {
 export type AnalyticsCallback = EndpointMetric => mixed;
 
 export type CommandOptions = {
-  ...AuthenticationOptions,
+  accessToken?: AccessTokenOption,
   analyticsCallback: AnalyticsCallback,
   apiUrl: string | Promise<string>,
   objectUrl: string | Promise<string>,
   previewUrl: string | Promise<string>,
+  shareId?: ShareIdOption,
   transportMode: ("api" | "cli")[],
   webUrl: string | Promise<string>
 };

--- a/src/types.js
+++ b/src/types.js
@@ -146,6 +146,11 @@ export type AccessTokenOption =
 export type ShareIdentifier = ?string | ShareDescriptor;
 export type ShareIdOption = () => Promise<ShareIdentifier>;
 
+type AuthenticationOptions = {
+  accessToken?: AccessTokenOption,
+  shareId?: ShareIdOption
+};
+
 export type EndpointMetric = {
   duration: number,
   endpoint: string,
@@ -156,12 +161,11 @@ export type EndpointMetric = {
 export type AnalyticsCallback = EndpointMetric => mixed;
 
 export type CommandOptions = {
-  accessToken: AccessTokenOption,
+  ...AuthenticationOptions,
   analyticsCallback: AnalyticsCallback,
   apiUrl: string | Promise<string>,
   objectUrl: string | Promise<string>,
   previewUrl: string | Promise<string>,
-  shareId?: ShareIdOption,
   transportMode: ("api" | "cli")[],
   webUrl: string | Promise<string>
 };

--- a/src/types.js
+++ b/src/types.js
@@ -143,7 +143,7 @@ export type AccessTokenOption =
   | (() => AccessToken) // TODO: Deprecate
   | (() => Promise<AccessToken>);
 
-export type ShareIdentifier = ?string | ShareDescriptor;
+export type ShareIdentifier = string | ShareDescriptor;
 export type ShareIdOption = () => Promise<ShareIdentifier>;
 
 export type EndpointMetric = {

--- a/src/types.js
+++ b/src/types.js
@@ -143,6 +143,9 @@ export type AccessTokenOption =
   | (() => AccessToken) // TODO: Deprecate
   | (() => Promise<AccessToken>);
 
+export type ShareToken = ?string | ShareDescriptor;
+export type ShareTokenOption = () => Promise<ShareToken>;
+
 export type EndpointMetric = {
   duration: number,
   endpoint: string,
@@ -158,6 +161,7 @@ export type CommandOptions = {
   apiUrl: string | Promise<string>,
   objectUrl: string | Promise<string>,
   previewUrl: string | Promise<string>,
+  shareToken?: ShareTokenOption,
   transportMode: ("api" | "cli")[],
   webUrl: string | Promise<string>
 };

--- a/src/types.js
+++ b/src/types.js
@@ -143,8 +143,8 @@ export type AccessTokenOption =
   | (() => AccessToken) // TODO: Deprecate
   | (() => Promise<AccessToken>);
 
-export type ShareToken = ?string | ShareDescriptor;
-export type ShareTokenOption = () => Promise<ShareToken>;
+export type ShareIdentifier = ?string | ShareDescriptor;
+export type ShareIdOption = () => Promise<ShareIdentifier>;
 
 export type EndpointMetric = {
   duration: number,
@@ -161,7 +161,7 @@ export type CommandOptions = {
   apiUrl: string | Promise<string>,
   objectUrl: string | Promise<string>,
   previewUrl: string | Promise<string>,
-  shareToken?: ShareTokenOption,
+  shareId?: ShareIdOption,
   transportMode: ("api" | "cli")[],
   webUrl: string | Promise<string>
 };

--- a/src/types.js
+++ b/src/types.js
@@ -143,8 +143,7 @@ export type AccessTokenOption =
   | (() => AccessToken) // TODO: Deprecate
   | (() => Promise<AccessToken>);
 
-export type ShareIdentifier = string | ShareDescriptor;
-export type ShareIdOption = () => Promise<ShareIdentifier>;
+export type ShareIdOption = () => Promise<string | ShareDescriptor>;
 
 export type EndpointMetric = {
   duration: number,

--- a/src/types.js
+++ b/src/types.js
@@ -137,7 +137,7 @@ export type CollectionsListOptions = {
   userId?: string
 };
 
-export type AccessToken = ?string | ShareDescriptor;
+export type AccessToken = ?string;
 export type AccessTokenOption =
   | AccessToken // TODO: Deprecate?
   | (() => AccessToken) // TODO: Deprecate

--- a/tests/Client.test.js
+++ b/tests/Client.test.js
@@ -11,7 +11,7 @@ import {
   CLIENT_CONFIG,
   CLI_CLIENT
 } from "../src/util/testing";
-import type { AccessToken, RequestOptions } from "../src/types";
+import type { RequestOptions } from "../src/types";
 
 const Client = require("../src/Client").default;
 
@@ -108,7 +108,7 @@ describe("Client", () => {
 
     const client = new Client({
       ...CLIENT_CONFIG,
-      accessToken: { shareId: "share-id" }
+      shareId: async () => ({ shareId: "share-id" })
     });
 
     mockAPI("/projects/project-id/branches/?", {
@@ -145,7 +145,7 @@ describe("Client", () => {
   test("shareDescriptor access token - cli", async () => {
     const client = new Client({
       ...CLIENT_CONFIG,
-      accessToken: (() => ({ shareId: "share-id" }): () => AccessToken)
+      shareId: async () => ({ shareId: "share-id" })
     });
 
     const spawnSpy = mockCLI(["branches", "list", "--project-id=project-id"], {

--- a/tests/Client.test.js
+++ b/tests/Client.test.js
@@ -137,6 +137,9 @@ describe("Client", () => {
     ]);
 
     expect(fetchSpy.mock.calls.length).toBe(1);
+    expect(fetchSpy.mock.calls[0][1].headers["Authorization"]).toBe(
+      `Bearer ${CLIENT_CONFIG.accessToken}`
+    );
     expect(fetchSpy.mock.calls[0][1].headers["Abstract-Share-Id"]).toBe(
       "share-id"
     );
@@ -172,7 +175,7 @@ describe("Client", () => {
     ]);
     expect((spawnSpy: any).mock.calls.length).toBe(1);
     expect((spawnSpy: any).mock.calls[0][1].includes("--user-token")).toBe(
-      false
+      true
     );
   });
 

--- a/tests/Client.test.js
+++ b/tests/Client.test.js
@@ -103,7 +103,7 @@ describe("Client", () => {
     ]);
   });
 
-  test("shareDescriptor access token - api", async () => {
+  test("shareDescriptor shareId - api", async () => {
     const fetchSpy = jest.spyOn(global, "fetch");
 
     const client = new Client({
@@ -142,6 +142,42 @@ describe("Client", () => {
     );
     expect(fetchSpy.mock.calls[0][1].headers["Abstract-Share-Id"]).toBe(
       "share-id"
+    );
+  });
+
+  test("shareDescriptor shareId and no accessToken - api", async () => {
+    const { accessToken, ...options } = CLIENT_CONFIG;
+    const client = new Client({
+      ...options,
+      shareId: async () => ({ shareId: "only-share-id" })
+    });
+
+    mockAPI("/projects/project-id/branches/?", {
+      data: {
+        branches: [
+          {
+            id: "branch-id"
+          }
+        ]
+      }
+    });
+
+    const fetchSpy = jest.spyOn(client.branches, "apiRequest");
+
+    await client.branches.list(
+      {
+        projectId: "project-id"
+      },
+      {
+        transportMode: ["api"]
+      }
+    );
+
+    expect(fetchSpy.mock.calls[0][1].headers).not.toHaveProperty(
+      "Authorization"
+    );
+    expect(fetchSpy.mock.calls[0][1].headers["Abstract-Share-Id"]).toBe(
+      "only-share-id"
     );
   });
 

--- a/tests/Client.test.js
+++ b/tests/Client.test.js
@@ -11,7 +11,7 @@ import {
   CLIENT_CONFIG,
   CLI_CLIENT
 } from "../src/util/testing";
-import type { RequestOptions } from "../src/types";
+import type { AccessToken, RequestOptions } from "../src/types";
 
 const Client = require("../src/Client").default;
 
@@ -103,116 +103,140 @@ describe("Client", () => {
     ]);
   });
 
-  test("shareDescriptor shareId - api", async () => {
-    const fetchSpy = jest.spyOn(global, "fetch");
+  describe("authentication methods", () => {
+    const projectDescriptor = { projectId: "project-id" };
 
-    const client = new Client({
-      ...CLIENT_CONFIG,
-      shareId: async () => ({ shareId: "share-id" })
+    describe("api", () => {
+      const requestOptions = { transportMode: ["api"] };
+
+      beforeEach(() => {
+        mockAPI("/projects/project-id/branches/?", {
+          data: {
+            branches: [
+              {
+                id: "branch-id"
+              }
+            ]
+          }
+        });
+      });
+
+      describe("authenticated", () => {
+        test("authenticated and shareId: ShareDescriptor", async () => {
+          const client = new Client({
+            ...CLIENT_CONFIG,
+            accessToken: async (): Promise<AccessToken> =>
+              CLIENT_CONFIG.accessToken,
+            shareId: async () => ({ shareId: "share-id" })
+          });
+
+          const fetchSpy = jest.spyOn(client.branches, "apiRequest");
+
+          const response = await client.branches.list(
+            projectDescriptor,
+            requestOptions
+          );
+
+          expect(response).toEqual([{ id: "branch-id" }]);
+
+          expect(fetchSpy.mock.calls.length).toBe(1);
+          expect(fetchSpy.mock.calls[0][1].headers["Authorization"]).toBe(
+            `Bearer ${CLIENT_CONFIG.accessToken}`
+          );
+          expect(fetchSpy.mock.calls[0][1].headers["Abstract-Share-Id"]).toBe(
+            "share-id"
+          );
+        });
+
+        test("authenticated and shareId: string", async () => {
+          const client = new Client({
+            ...CLIENT_CONFIG,
+            shareId: async () => "share-id-string"
+          });
+
+          const fetchSpy = jest.spyOn(client.branches, "apiRequest");
+
+          await client.branches.list(projectDescriptor, requestOptions);
+
+          expect(fetchSpy.mock.calls[0][1].headers["Authorization"]).toBe(
+            `Bearer ${CLIENT_CONFIG.accessToken}`
+          );
+          expect(fetchSpy.mock.calls[0][1].headers["Abstract-Share-Id"]).toBe(
+            "share-id-string"
+          );
+        });
+      });
+
+      test("public access (not authenticated) and shareId: ShareDescriptor", async () => {
+        const { accessToken, ...options } = CLIENT_CONFIG;
+        const client = new Client({
+          ...options,
+          shareId: async () => ({ shareId: "only-share-id" })
+        });
+
+        const fetchSpy = jest.spyOn(client.branches, "apiRequest");
+
+        await client.branches.list(projectDescriptor, requestOptions);
+
+        expect(fetchSpy.mock.calls[0][1].headers).not.toHaveProperty(
+          "Authorization"
+        );
+        expect(fetchSpy.mock.calls[0][1].headers["Abstract-Share-Id"]).toBe(
+          "only-share-id"
+        );
+      });
     });
 
-    mockAPI("/projects/project-id/branches/?", {
-      data: {
-        branches: [
+    describe("cli", () => {
+      let spawnSpy;
+      const requestOptions = { transportMode: ["cli"] };
+
+      beforeEach(() => {
+        spawnSpy = mockCLI(["branches", "list", "--project-id=project-id"], {
+          branches: [
+            {
+              id: "branch-id"
+            }
+          ]
+        });
+      });
+
+      test("authenticated and shareId: ShareDescriptor", async () => {
+        const client = new Client({
+          ...CLIENT_CONFIG,
+          shareId: async () => ({ shareId: "share-id" })
+        });
+
+        const response = await client.branches.list(
+          projectDescriptor,
+          requestOptions
+        );
+
+        expect(response).toEqual([
           {
             id: "branch-id"
           }
-        ]
-      }
+        ]);
+        expect((spawnSpy: any).mock.calls.length).toBe(1);
+        expect((spawnSpy: any).mock.calls[0][1].includes("--user-token")).toBe(
+          true
+        );
+      });
+
+      test("not authenticated and shareId: ShareDescriptor", async () => {
+        const { accessToken, ...options } = CLIENT_CONFIG;
+        const client = new Client({
+          ...options,
+          shareId: async () => ({ shareId: "share-id" })
+        });
+
+        await client.branches.list(projectDescriptor, requestOptions);
+
+        expect((spawnSpy: any).mock.calls[0][1].includes("--user-token")).toBe(
+          false
+        );
+      });
     });
-
-    const response = await client.branches.list(
-      {
-        projectId: "project-id"
-      },
-      {
-        transportMode: ["api"]
-      }
-    );
-
-    expect(response).toEqual([
-      {
-        id: "branch-id"
-      }
-    ]);
-
-    expect(fetchSpy.mock.calls.length).toBe(1);
-    expect(fetchSpy.mock.calls[0][1].headers["Authorization"]).toBe(
-      `Bearer ${CLIENT_CONFIG.accessToken}`
-    );
-    expect(fetchSpy.mock.calls[0][1].headers["Abstract-Share-Id"]).toBe(
-      "share-id"
-    );
-  });
-
-  test("shareDescriptor shareId and no accessToken - api", async () => {
-    const { accessToken, ...options } = CLIENT_CONFIG;
-    const client = new Client({
-      ...options,
-      shareId: async () => ({ shareId: "only-share-id" })
-    });
-
-    mockAPI("/projects/project-id/branches/?", {
-      data: {
-        branches: [
-          {
-            id: "branch-id"
-          }
-        ]
-      }
-    });
-
-    const fetchSpy = jest.spyOn(client.branches, "apiRequest");
-
-    await client.branches.list(
-      {
-        projectId: "project-id"
-      },
-      {
-        transportMode: ["api"]
-      }
-    );
-
-    expect(fetchSpy.mock.calls[0][1].headers).not.toHaveProperty(
-      "Authorization"
-    );
-    expect(fetchSpy.mock.calls[0][1].headers["Abstract-Share-Id"]).toBe(
-      "only-share-id"
-    );
-  });
-
-  test("shareDescriptor access token - cli", async () => {
-    const client = new Client({
-      ...CLIENT_CONFIG,
-      shareId: async () => ({ shareId: "share-id" })
-    });
-
-    const spawnSpy = mockCLI(["branches", "list", "--project-id=project-id"], {
-      branches: [
-        {
-          id: "branch-id"
-        }
-      ]
-    });
-
-    const response = await client.branches.list(
-      {
-        projectId: "project-id"
-      },
-      {
-        transportMode: ["cli"]
-      }
-    );
-
-    expect(response).toEqual([
-      {
-        id: "branch-id"
-      }
-    ]);
-    expect((spawnSpy: any).mock.calls.length).toBe(1);
-    expect((spawnSpy: any).mock.calls[0][1].includes("--user-token")).toBe(
-      true
-    );
   });
 
   test("undefined request options", async () => {

--- a/tests/Client.test.js
+++ b/tests/Client.test.js
@@ -122,7 +122,7 @@ describe("Client", () => {
       });
 
       describe("authenticated", () => {
-        test("authenticated and shareId: ShareDescriptor", async () => {
+        test("shareId: ShareDescriptor", async () => {
           const client = new Client({
             ...CLIENT_CONFIG,
             accessToken: async (): Promise<AccessToken> =>
@@ -148,7 +148,7 @@ describe("Client", () => {
           );
         });
 
-        test("authenticated and shareId: string", async () => {
+        test("shareId: string", async () => {
           const client = new Client({
             ...CLIENT_CONFIG,
             shareId: async () => "share-id-string"


### PR DESCRIPTION
We recently ran into an issue where some requests on private share link pages would fail because we were only allowing a single `accessToken`. For these share links, `accessToken` was being set to the share ID, and the authentication header would never get configured.

This PR adds a separate `shareId` option that can be set in addition to the `accessToken`, allowing both headers to exist on a request.