### PR TITLE
fix: Correctly handle error when CLI response is unparsable

### DIFF
--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -249,6 +249,7 @@ export default class Endpoint {
           logCLIResponse.enabled && logCLIResponse(cliResponse);
           resolve(cliResponse);
         } catch (error) {
+          /* istanbul ignore next */
           reject(error);
         }
       });

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -233,8 +233,8 @@ export default class Endpoint {
 
       response.on("close", errCode => {
         if (errCode !== 0) {
-          const response = JSON.parse(errBuffer.toString());
           try {
+            const response = JSON.parse(errBuffer.toString());
             throwCLIError(response, spawnArgs[0], { ...(spawnArgs[1]: any) });
           } catch (error) {
             reject(error);
@@ -242,12 +242,15 @@ export default class Endpoint {
           return;
         }
 
-        const cliResponse = JSON.parse(outBuffer.toString());
+        try {
+          const cliResponse = JSON.parse(outBuffer.toString());
 
-        /* istanbul ignore next */
-        logCLIResponse.enabled && logCLIResponse(cliResponse);
-
-        resolve(cliResponse);
+          /* istanbul ignore next */
+          logCLIResponse.enabled && logCLIResponse(cliResponse);
+          resolve(cliResponse);
+        } catch (error) {
+          reject(error);
+        }
       });
     });
   }


### PR DESCRIPTION
It is unlikely, but possible for the CLI to respond with something that is not JSON-parsable. Currently if this happens an uncaught error is thrown. In our applications this would result in a request that is never resolved.

This change makes sure that the error is caught and the promise is properly rejected.

![image](https://user-images.githubusercontent.com/380914/81241022-f463e600-8fbd-11ea-911c-672ff0d67585.png)
