### PR TITLE
chore: Remove features from organizations response

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -728,7 +728,6 @@ type Membership = {
 };
 
 type Organization = {
-  features: { [feature: string]: boolean },
   hasBillingInfo?: boolean,
   id: string,
   isUsernameOrganization?: boolean,

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -1385,7 +1385,6 @@ Organizations contain users and projects.
 
 | Property                   | Type       | Description                                                                              |
 |----------------------------|------------|------------------------------------------------------------------------------------------|
-| `features`                 | `{[feature: string]: boolean}` | Map of feature flags enabled for this organization                   |
 | `hasBillingInfo`           | `boolean`  | Whether this organization has billing information on file                                |
 | `id`                       | `string`   | UUID                                                                                     |
 | `isUsernameOrganization`   | `boolean`  | A username organization is a free organization included with every user account          |

--- a/src/endpoints/Organizations.js
+++ b/src/endpoints/Organizations.js
@@ -7,6 +7,11 @@ import type {
 import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
 
+// Version 27 does not return features for organizations
+const headers = {
+  "Abstract-Api-Version": "27"
+};
+
 export default class Organizations extends Endpoint {
   name = "organizations";
 
@@ -17,7 +22,10 @@ export default class Organizations extends Endpoint {
     return this.configureRequest<Promise<Organization>>("info", {
       api: async () => {
         const response = await this.apiRequest(
-          `organizations/${descriptor.organizationId}`
+          `organizations/${descriptor.organizationId}`,
+          {
+            headers
+          }
         );
 
         return wrap(response.data, response);
@@ -29,7 +37,9 @@ export default class Organizations extends Endpoint {
   list(requestOptions: RequestOptions = {}) {
     return this.configureRequest<Promise<Organization[]>>("list", {
       api: async () => {
-        const response = await this.apiRequest("organizations");
+        const response = await this.apiRequest("organizations", {
+          headers
+        });
         return wrap(response.data, response);
       },
       requestOptions

--- a/src/types.js
+++ b/src/types.js
@@ -459,7 +459,6 @@ export type Membership = {
 };
 
 export type Organization = {
-  features: { [feature: string]: boolean },
   hasBillingInfo?: boolean,
   id: string,
   isUsernameOrganization?: boolean,


### PR DESCRIPTION
In order to make API requests more performant we no longer return feature flags inside of organization payloads.