### PR TITLE
chore: Add stream package as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "debug": "^4.0.1",
     "js-sha256": "^0.9.0",
     "query-string": "^6.1.0",
+    "stream": "0.0.2",
     "uuid": "^3.3.2"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Description

- Add stream as a dependency of the package. 

When using this package in a Ember Application I get the following error: 

<img width="1423" alt="Screenshot 2020-07-06 at 15 27 37" src="https://user-images.githubusercontent.com/344518/86599181-8d06ea00-bf9e-11ea-92d2-d0287ba0f7ae.png">

If I look at the file in the dust folder I can see the require to stream:

<img width="630" alt="Screenshot 2020-07-06 at 15 37 49" src="https://user-images.githubusercontent.com/344518/86599311-bde71f00-bf9e-11ea-98bc-41a820025726.png">


## Note

It could be related to a specific configuration of the build process of the app, but, if it doesn't cause any harm for you, it will be cool to avoid the problem by adding the explicit dependency in the package.json.

Best regards,
Danie.
