### PR TITLE
feat(oauth): add CommandOptions properties

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -1855,8 +1855,10 @@ type CommandOptions = {
   apiUrl: string | Promise<string>,
   analyticsCallback: AnalyticsCallback,
   assetUrl: string | Promise<string>,
+  clientSecret?: string | Promise<string>,
   previewUrl: string | Promise<string>,
   shareId?: () => Promise<string | ShareDescriptor | ShareUrlDescriptor | void>,
+  redirectUri?: string | Promise<string>,
   transportMode: ("api" | "cli")[],
   webUrl: string | Promise<string>
 };

--- a/src/types.js
+++ b/src/types.js
@@ -159,6 +159,7 @@ export type CommandOptions = {
   accessToken?: AccessTokenOption,
   analyticsCallback: AnalyticsCallback,
   apiUrl: string | Promise<string>,
+  clientId?: string,
   clientSecret?: string | Promise<string>,
   objectUrl: string | Promise<string>,
   previewUrl: string | Promise<string>,

--- a/src/types.js
+++ b/src/types.js
@@ -164,7 +164,7 @@ export type CommandOptions = {
   objectUrl: string | Promise<string>,
   previewUrl: string | Promise<string>,
   shareId?: () => Promise<string | ShareDescriptor | ShareUrlDescriptor | void>,
-  redirectUri?: string | Promise<string>,
+  redirectUri?: string,
   transportMode: ("api" | "cli")[],
   webUrl: string | Promise<string>
 };

--- a/src/types.js
+++ b/src/types.js
@@ -159,9 +159,11 @@ export type CommandOptions = {
   accessToken?: AccessTokenOption,
   analyticsCallback: AnalyticsCallback,
   apiUrl: string | Promise<string>,
+  clientSecret?: string | Promise<string>,
   objectUrl: string | Promise<string>,
   previewUrl: string | Promise<string>,
   shareId?: () => Promise<string | ShareDescriptor | ShareUrlDescriptor | void>,
+  redirectUri?: string | Promise<string>,
   transportMode: ("api" | "cli")[],
   webUrl: string | Promise<string>
 };


### PR DESCRIPTION
This PR is the 1st part of adding OAuth2.0 into Abstract SDK.
[Link to OAUTH2.0 RFC](https://goabstract.atlassian.net/wiki/spaces/ENG/pages/341705615/OAuth+2.0)
[Link to OAuth interface for SDK](https://goabstract.atlassian.net/wiki/spaces/ENG/pages/447643698/RFC+OAuth+interface+for+JavaScript+SDK#Architecture-Summary)

Adds `clientId`, `clientSecret` and `redirectUri` as CommandOptions properties when setting up `Abstract.Client`.