### PR TITLE
docs: Update embed docs for public shares

### DIFF
--- a/docs/embed.md
+++ b/docs/embed.md
@@ -5,8 +5,6 @@ title: Embeds
 
 Embeds can be used to display interactive, up-to-date previews for layers and collections in any environment that supports HTML. To use an embed, create an `<iframe>` with a special URL derived from public share URLs.
 
-> Note: Only links for publicly-shared layers or collections can be embedded at this time.
-
 ## Generating an embed
 
 <div id="embed-gen">


### PR DESCRIPTION
Embeds for private shares authenticate as expected if you are logged into abstract.com https://github.com/goabstract/ui/pull/3068

Example from Abstract org:
https://app.abstract.com/embed/09c340f4-476f-41e0-8247-22795d57ec95
