### PR TITLE
chore: update release process checklist for contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,8 +90,7 @@ $ yarn start
 
 New package versions of `abstract-sdk` are automatically published to the public NPM registry whenever new tags are pushed to the repository. This repository uses [`standard-version`](https://github.com/conventional-changelog/standard-version) as convention to automate versioning, tagging, and changelog generation:
 
-1. Bump the version and submit a pull request.
-   For a prerelease, add the `--prerelease` flag when running `yarn release`:
+1. Bump the version and submit a pull request. For a prerelease, add the `--prerelease` flag when running `yarn release`:
    ```sh
    $ yarn release
    $ git push origin <new_tag_version>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,16 +92,20 @@ New package versions of `abstract-sdk` are automatically published to the public
 
 1. Bump the version and submit a pull request.
     ```sh
-    $ yarn release
+    $ yarn release --prerelease
     $ git push origin <new_tag_version>
     ```
 2. Once the PR lands, push the new tag to the repository.
     ```sh
     $ git push origin <new_tag_version>
     ```
+    or
+    ```sh
+    $ git push --follow-tags
+    ``` 
 3. Lastly, update the documentation.
     ```sh
-    $ git checkout docs
+    $ git checkout -t origin/docs -b docs
     $ git rebase master
     $ git push origin docs -f
     ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,8 +91,9 @@ $ yarn start
 New package versions of `abstract-sdk` are automatically published to the public NPM registry whenever new tags are pushed to the repository. This repository uses [`standard-version`](https://github.com/conventional-changelog/standard-version) as convention to automate versioning, tagging, and changelog generation:
 
 1. Bump the version and submit a pull request.
+   For a prerelease, add the `--prerelease` flag when running `yarn release`:
    ```sh
-   $ yarn release --prerelease
+   $ yarn release
    $ git push origin <new_tag_version>
    ```
 2. Once the PR lands, push the new tag to the repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,27 +91,29 @@ $ yarn start
 New package versions of `abstract-sdk` are automatically published to the public NPM registry whenever new tags are pushed to the repository. This repository uses [`standard-version`](https://github.com/conventional-changelog/standard-version) as convention to automate versioning, tagging, and changelog generation:
 
 1. Bump the version and submit a pull request.
-    ```sh
-    $ yarn release --prerelease
-    $ git push origin <new_tag_version>
-    ```
+   ```sh
+   $ yarn release --prerelease
+   $ git push origin <new_tag_version>
+   ```
 2. Once the PR lands, push the new tag to the repository.
-    ```sh
-    $ git push origin <new_tag_version>
-    ```
-    or
-    ```sh
-    $ git push --follow-tags
-    ``` 
+   ```sh
+   $ git push origin <new_tag_version>
+   ```
+   or
+   ```sh
+   $ git push --follow-tags
+   ```
 3. Lastly, update the documentation.
-    ```sh
-    $ git checkout -t origin/docs -b docs
-    $ git rebase master
-    $ git push origin docs -f
-    ```
+   ```sh
+   $ git checkout -t origin/docs -b docs
+   $ git rebase master
+   $ git push origin docs -f
+   ```
 
 <br />
 <br />
 <br />
 <br />
-<img src="https://www.abstract.com/wp-content/uploads/abstract-black-wordmark-rgb.png" width="136" height="auto" />
+<img
+src="https://user-images.githubusercontent.com/12195101/87982812-5902ed00-caa5-11ea-8acc-1291ca41111d.png"
+width="136" height="auto" alt="Abstract black wordmark" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,10 +99,6 @@ New package versions of `abstract-sdk` are automatically published to the public
    ```sh
    $ git push origin <new_tag_version>
    ```
-   or
-   ```sh
-   $ git push --follow-tags
-   ```
 3. Lastly, update the documentation.
    ```sh
    $ git checkout -t origin/docs -b docs


### PR DESCRIPTION
This PR updates the documentation for the steps to take for cutting a new release + fixes the broken footer image link:

<img width="1854" alt="Screen Shot 2020-07-20 at 4 25 57 PM" src="https://user-images.githubusercontent.com/12195101/87983045-c151ce80-caa5-11ea-9f19-bff9ec80bbb8.png">
