### PR TITLE
fix: Update API version passed to project create/update

### DIFF
--- a/src/endpoints/Projects.js
+++ b/src/endpoints/Projects.js
@@ -78,7 +78,7 @@ export default class Projects extends Endpoint {
           method: "POST",
           body: project
         });
-        return wrap(response.data.project, response);
+        return wrap(response);
       },
       requestOptions
     });
@@ -101,7 +101,7 @@ export default class Projects extends Endpoint {
             body: project
           }
         );
-        return wrap(response.data.project, response);
+        return wrap(response);
       },
       requestOptions
     });

--- a/src/endpoints/Projects.js
+++ b/src/endpoints/Projects.js
@@ -74,10 +74,11 @@ export default class Projects extends Endpoint {
     return this.configureRequest<Promise<Project>>("create", {
       api: async () => {
         const response = await this.apiRequest(`projects`, {
+          headers,
           method: "POST",
           body: project
         });
-        return wrap(response);
+        return wrap(response.data.project, response);
       },
       requestOptions
     });
@@ -95,11 +96,12 @@ export default class Projects extends Endpoint {
         const response = await this.apiRequest(
           `projects/${descriptor.projectId}`,
           {
+            headers,
             method: "PUT",
             body: project
           }
         );
-        return wrap(response);
+        return wrap(response.data.project, response);
       },
       requestOptions
     });


### PR DESCRIPTION
Using version >= 22 to ensure that the repo is created on the server and does not require the desktop app, which makes a lot of sense for the SDK 😉 