### PR TITLE
fix: Add ValidationError class

### DIFF
--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -90,7 +90,10 @@ export default class Endpoint {
         }
       }
 
-      if (Object.keys(errors).length === transportMode.length) {
+      if (
+        transportMode.length > 1 &&
+        Object.keys(errors).length === transportMode.length
+      ) {
         throw new MultiError(errors);
       }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -109,6 +109,15 @@ export class ServiceUnavailableError extends BaseError {
   }
 }
 
+export class ValidationError extends BaseError {
+  data: ErrorData;
+
+  constructor(path: string, body: Object) {
+    super("Validation failed.");
+    this.data = { path, body };
+  }
+}
+
 export class FileExportError extends BaseError {
   constructor(fileId: string, exportId: string) {
     super(
@@ -132,6 +141,8 @@ export async function throwAPIError(
       throw new ForbiddenError(url, body);
     case 404:
       throw new NotFoundError(url, body);
+    case 422:
+      throw new ValidationError(url, body);
     case 429:
       throw new RateLimitError(url, body, response);
     case 500:
@@ -162,6 +173,8 @@ export function throwCLIError(
       throw new RateLimitError(cliPath, args);
     case "service_unavailable":
       throw new ServiceUnavailableError(cliPath, args);
+    case "validation_error":
+      throw new ValidationError(cliPath, args);
     default:
       throw new Error(response.message);
   }

--- a/src/errors.js
+++ b/src/errors.js
@@ -112,7 +112,7 @@ export class ServiceUnavailableError extends BaseError {
 export class ValidationError extends BaseError {
   data: ErrorData;
 
-  constructor(path: string, body: Object) {
+  constructor(path: string, body: mixed) {
     super("Validation failed.");
     this.data = { path, body };
   }

--- a/tests/Client.test.js
+++ b/tests/Client.test.js
@@ -33,7 +33,7 @@ describe("Client", () => {
 
     try {
       await API_CLIENT.organizations.list({
-        transportMode: ["cli"]
+        transportMode: ["api", "cli"]
       });
     } catch (error) {
       expect(error).toBeInstanceOf(MultiError);

--- a/tests/errors.test.js
+++ b/tests/errors.test.js
@@ -10,6 +10,7 @@ import {
   UnauthorizedError,
   throwAPIError,
   InternalServerError,
+  ValidationError,
   throwCLIError
 } from "../src/errors";
 
@@ -82,6 +83,14 @@ describe("errors", () => {
         await throwAPIError(getResponse({ status: 503 }), "url", "body");
       } catch (error) {
         expect(error).toBeInstanceOf(ServiceUnavailableError);
+      }
+    });
+
+    test("ValidationError", async () => {
+      try {
+        await throwAPIError(getResponse({ status: 422 }), "url", "body");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ValidationError);
       }
     });
 
@@ -162,6 +171,14 @@ describe("errors", () => {
         );
       } catch (error) {
         expect(error).toBeInstanceOf(ServiceUnavailableError);
+      }
+    });
+
+    test("ValidationError", async () => {
+      try {
+        await throwCLIError(({ code: "validation_error" }: any), "cliPath", {});
+      } catch (error) {
+        expect(error).toBeInstanceOf(ValidationError);
       }
     });
 


### PR DESCRIPTION
Validation errors are one of the most common error types, yet we weren't giving it it's own class/handler.

Also no longer throws `MultiError` when only a single transport is used. 

closes #279