### PR TITLE
fix: Broken error handling

### DIFF
--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -90,10 +90,11 @@ export default class Endpoint {
         }
       }
 
-      if (
-        transportMode.length > 1 &&
-        Object.keys(errors).length === transportMode.length
-      ) {
+      const totalErrors = Object.keys(errors).length;
+      if (transportMode.length === totalErrors) {
+        if (totalErrors === 1) {
+          throw Object.values(errors)[0];
+        }
         throw new MultiError(errors);
       }
 

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -206,11 +206,13 @@ describe("branches", () => {
     });
 
     test("cli - no descriptor", async () => {
+      let error;
       try {
         await CLI_CLIENT.branches.list(undefined);
-      } catch (error) {
-        expect(error).toBeInstanceOf(BranchSearchCLIError);
+      } catch (e) {
+        error = e;
       }
+      expect(error).toBeInstanceOf(BranchSearchCLIError);
     });
   });
 

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -209,7 +209,7 @@ describe("branches", () => {
       try {
         await CLI_CLIENT.branches.list(undefined);
       } catch (error) {
-        expect(error.errors.cli).toBeInstanceOf(BranchSearchCLIError);
+        expect(error).toBeInstanceOf(BranchSearchCLIError);
       }
     });
   });

--- a/tests/endpoints/Files.test.js
+++ b/tests/endpoints/Files.test.js
@@ -48,7 +48,7 @@ describe("files", () => {
           sha: "sha"
         });
       } catch (error) {
-        expect(error.errors.api).toBeInstanceOf(NotFoundError);
+        expect(error).toBeInstanceOf(NotFoundError);
       }
     });
 
@@ -221,7 +221,7 @@ describe("files", () => {
           sha: "sha"
         });
       } catch (error) {
-        expect(error.errors.api).toBeInstanceOf(FileExportError);
+        expect(error).toBeInstanceOf(FileExportError);
       }
     });
 

--- a/tests/endpoints/Files.test.js
+++ b/tests/endpoints/Files.test.js
@@ -40,6 +40,7 @@ describe("files", () => {
         ]
       });
 
+      let error;
       try {
         await API_CLIENT.files.info({
           branchId: "branch-id",
@@ -47,9 +48,10 @@ describe("files", () => {
           projectId: "project-id",
           sha: "sha"
         });
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotFoundError);
+      } catch (e) {
+        error = e;
       }
+      expect(error).toBeInstanceOf(NotFoundError);
     });
 
     test("cli", async () => {
@@ -213,6 +215,7 @@ describe("files", () => {
         );
       });
 
+      let error;
       try {
         await API_CLIENT.files.raw({
           branchId: "branch-id",
@@ -220,9 +223,10 @@ describe("files", () => {
           projectId: "project-id",
           sha: "sha"
         });
-      } catch (error) {
-        expect(error).toBeInstanceOf(FileExportError);
+      } catch (e) {
+        error = e;
       }
+      expect(error).toBeInstanceOf(FileExportError);
     });
 
     test("cli - exports file", async () => {

--- a/tests/endpoints/Pages.test.js
+++ b/tests/endpoints/Pages.test.js
@@ -49,7 +49,7 @@ describe("pages", () => {
           sha: "sha"
         });
       } catch (error) {
-        expect(error.errors.api).toBeInstanceOf(NotFoundError);
+        expect(error).toBeInstanceOf(NotFoundError);
       }
     });
 
@@ -93,7 +93,7 @@ describe("pages", () => {
           sha: "sha"
         });
       } catch (error) {
-        expect(error.errors.cli).toBeInstanceOf(NotFoundError);
+        expect(error).toBeInstanceOf(NotFoundError);
       }
     });
   });

--- a/tests/endpoints/Pages.test.js
+++ b/tests/endpoints/Pages.test.js
@@ -84,6 +84,7 @@ describe("pages", () => {
         ]
       });
 
+      let error;
       try {
         await CLI_CLIENT.pages.info({
           branchId: "branch-id",
@@ -92,9 +93,10 @@ describe("pages", () => {
           projectId: "project-id",
           sha: "sha"
         });
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotFoundError);
+      } catch (e) {
+        error = e;
       }
+      expect(error).toBeInstanceOf(NotFoundError);
     });
   });
 

--- a/tests/errors.test.js
+++ b/tests/errors.test.js
@@ -122,7 +122,7 @@ describe("errors", () => {
       try {
         await CLI_CLIENT.projects.list({ organizationId: "org-id" });
       } catch (error) {
-        expect(error.errors.cli).toBeInstanceOf(EndpointUndefinedError);
+        expect(error).toBeInstanceOf(EndpointUndefinedError);
       }
     });
 

--- a/tests/util/helpers.test.js
+++ b/tests/util/helpers.test.js
@@ -17,12 +17,14 @@ describe("helpers", () => {
   });
 
   test("inferShareId throws", () => {
+    let error;
     try {
       utils.inferShareId(({}: any));
-    } catch (error) {
-      expect(error).toBeInstanceOf(Error);
-      expect(error.message).toContain("Could not infer share id");
+    } catch (e) {
+      error = e;
     }
+    expect(error).toBeInstanceOf(Error);
+    expect(error && error.message).toContain("Could not infer share id");
   });
 
   test("isNodeEnvironment", () => {


### PR DESCRIPTION
Error handling was totally broken by this PR: https://github.com/goabstract/abstract-sdk/pull/301 – and subsequently in the last beta release.

If a single transport is chosen and a single error happens the error handler is never called, instead you get an empty response in the success handler.

See comments for more details.