### PR TITLE
fix: Fix type for Webhook

### DIFF
--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -116,7 +116,7 @@ interface Endpoint {
     config: RequestConfig<T>,
     requestOptions?: RequestOptions
   ): T;
-    
+
   apiRequest(
     url: string,
     fetchOptions?: Object,
@@ -1870,16 +1870,14 @@ type Section = {
 };
 
 type Webhook = {
-  active: boolean,
   createdAt: string,
-  errorCount?: number,
-  events: string[],
-  id: string,
-  lastPushedAt?: string,
-  organizationId: string,
-  updatedAt: string,
-  url: string,
-  user?: User
+  event: string,
+  data: {
+    object: Branch,
+    changes: {
+      status: string[]
+    }
+  }
 };
 
 type WebhookGroup = {


### PR DESCRIPTION
as this is the response I receive

```
const mockAbstractWebhookResponseMergedIntoMaster = {
  createdAt: '2020-07-29T09:55:04Z',
  event: 'branch.statusUpdated',
  data: {
    changes: {
      status: ['wip', 'merged']
    },
    object: {
      createdAt: '2020-07-29T09:52:44Z',
      description: '',
      divergedFromBranchId: '',
      head: 'XXX',
      id: 'XXX',
      mergeSha: 'XXX',
      mergedIntoBranchId: 'master',
      name: 'test-2',
      objectType: 'branch',
      parent: 'master',
      projectId: 'XXX',
      startedAtSha: 'XXX',
      status: 'merged',
      updatedAt: '2020-07-29T09:54:46Z',
      user: {
        avatarUrl:
          'https://www.gravatar.com/avatar/XXX?r=pg&s=160&d=404',
        createdAt: '2019-08-22T06:51:02Z',
        id: 'XXX',
        name: 'XXX',
        objectType: 'user',
        updatedAt: '2019-08-22T06:51:02Z',
        username: 'XXX'
      }
    }
  }
}

export default mockAbstractWebhookResponseMergedIntoMaster
```

I think Webhook type should be updated