### PR TITLE
feat: adds update method to Branch endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [8.0.0-beta.37](https://github.com/goabstract/abstract-sdk/compare/v8.0.0-beta.36...v8.0.0-beta.37) (2020-09-17)
+
+
+### Features
+
+* adds branches.update info to sdk docs ([eb4852b](https://github.com/goabstract/abstract-sdk/commit/eb4852b9d319c52ffcee8a0af3da3f91e5c93cc9))
+* adds tests for branches.update method ([b1ee544](https://github.com/goabstract/abstract-sdk/commit/b1ee544313423a653a033e2e70d5d5d43b6345aa))
+* adds update method to Branch endpoint ([1eef2f0](https://github.com/goabstract/abstract-sdk/commit/1eef2f07c638cfef9016b919e7c5a7a082a27376))
+
+
+### Bug Fixes
+
+* Broken wordmark image in README ([#306](https://github.com/goabstract/abstract-sdk/issues/306)) ([3507f65](https://github.com/goabstract/abstract-sdk/commit/3507f65dc556c4842de78477a542bad379a36ac1))
+
 ## [8.0.0-beta.36](https://github.com/goabstract/abstract-sdk/compare/v8.0.0-beta.35...v8.0.0-beta.36) (2020-07-31)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
-* adds branches.update info to sdk docs ([eb4852b](https://github.com/goabstract/abstract-sdk/commit/eb4852b9d319c52ffcee8a0af3da3f91e5c93cc9))
-* adds tests for branches.update method ([b1ee544](https://github.com/goabstract/abstract-sdk/commit/b1ee544313423a653a033e2e70d5d5d43b6345aa))
-* adds update method to Branch endpoint ([1eef2f0](https://github.com/goabstract/abstract-sdk/commit/1eef2f07c638cfef9016b919e7c5a7a082a27376))
+* adds update method to Branch endpoint ([1eef2f0](https://github.com/goabstract/abstract-sdk/commit/1eef2f07c638cfef9016b919e7c5a7a082a27376)), adds respective tests ([b1ee544](https://github.com/goabstract/abstract-sdk/commit/b1ee544313423a653a033e2e70d5d5d43b6345aa)), and updates sdk docs ([eb4852b](https://github.com/goabstract/abstract-sdk/commit/eb4852b9d319c52ffcee8a0af3da3f91e5c93cc9))
 
 
 ### Bug Fixes

--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -154,6 +154,7 @@ interface Branches extends Endpoint {
     options?: RequestOptions & { filter?: "active" | "archived" | "mine", search?: string }
   ): Promise<Branch[]>;
   mergeState(descriptor: BranchDescriptor, options?: { parent?: string }): Promise<BranchMergeState>;
+  update(descriptor: BranchDescriptor, branchInput: BranchInput, options?: { ...RequestOptions, user?: User } = {})
 }
 
 interface Changesets extends Endpoint {

--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -154,7 +154,11 @@ interface Branches extends Endpoint {
     options?: RequestOptions & { filter?: "active" | "archived" | "mine", search?: string }
   ): Promise<Branch[]>;
   mergeState(descriptor: BranchDescriptor, options?: { parent?: string }): Promise<BranchMergeState>;
-  update(descriptor: BranchDescriptor, branchInput: BranchInput, options?: { ...RequestOptions, user?: User } = {})
+  update(
+    descriptor: BranchDescriptor,
+    branchInput: BranchInput,
+    options?: RequestOptions & { user?: User }
+  ): Promise<Branch>;
 }
 
 interface Changesets extends Endpoint {

--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -1064,6 +1064,12 @@ export type BranchMergeState = {
   behind?: number
 };
 
+type BranchInput = {
+  name?: string,
+  description?: string,
+  status?: string
+};
+
 type ChangesetStatus =
   "added"
   | "deleted"

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -307,7 +307,7 @@ abstract.branches.mergeState({
 
 ![CLI][cli-icon] ![API][api-icon]
 
-`branches.update(BranchDescriptor, BranchUpdateOptions, RequestOptions): Promise<Branch>`
+`branches.update(BranchDescriptor, BranchUpdateOptions): Promise<Branch>`
 
 Update an existing branch
 

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -307,7 +307,7 @@ abstract.branches.mergeState({
 
 ![CLI][cli-icon] ![API][api-icon]
 
-`branches.update(BranchDescriptor, UpdatedBranch, RequestOptions): Promise<Branch>`
+`branches.update(BranchDescriptor, BranchInput, RequestOptions): Promise<Branch>`
 
 Update an existing branch
 

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -303,7 +303,7 @@ abstract.branches.mergeState({
 
 > Note: The API and CLI [transports](/docs/transports) behave differently for merge state. The CLI transport ignores `options.parentId`, and _only_ returns one of the three possible merge states (no other fields are included). The API transport includes a value for each field of `BranchMergeState`, and only returns statuses `CLEAN` or `NEEDS_UPDATE`.
 
-### Update a collection
+### Update a branch
 
 ![CLI][cli-icon] ![API][api-icon]
 

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -303,6 +303,27 @@ abstract.branches.mergeState({
 
 > Note: The API and CLI [transports](/docs/transports) behave differently for merge state. The CLI transport ignores `options.parentId`, and _only_ returns one of the three possible merge states (no other fields are included). The API transport includes a value for each field of `BranchMergeState`, and only returns statuses `CLEAN` or `NEEDS_UPDATE`.
 
+### Update a collection
+
+![CLI][cli-icon] ![API][api-icon]
+
+`branches.update(BranchDescriptor, BranchUpdateOptions, RequestOptions): Promise<Branch>`
+
+Update an existing branch
+
+```js
+abstract.branches.update({
+  projectId: "616daa90-1736-11e8-b8b0-8d1fec7aef78",
+  branchId: "master"
+}, {
+  name: "New name",
+  description: "New description"
+});
+```
+
+
+
+
 ## Changesets
 
 A changeset is a group of changes that together form a single, indivisible modification to a project. Changesets include data on all visual and nonvisual changes and provide insight into the differences between two versions of a project.

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -317,11 +317,10 @@ abstract.branches.update({
   branchId: "master"
 }, {
   name: "New name",
-  description: "New description"
+  description: "New description",
+  status: "development"
 });
 ```
-
-
 
 
 ## Changesets

--- a/docs/abstract-api.md
+++ b/docs/abstract-api.md
@@ -307,7 +307,7 @@ abstract.branches.mergeState({
 
 ![CLI][cli-icon] ![API][api-icon]
 
-`branches.update(BranchDescriptor, BranchUpdateOptions): Promise<Branch>`
+`branches.update(BranchDescriptor, UpdatedBranch, RequestOptions): Promise<Branch>`
 
 Update an existing branch
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abstract-sdk",
-  "version": "8.0.0-beta.36",
+  "version": "8.0.0-beta.37",
   "description": "Universal JavaScript bindings for the Abstract API and CLI",
   "keywords": [
     "abstract",

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -6,6 +6,7 @@ import type {
   BranchMergeState,
   ListOptions,
   ProjectDescriptor,
+  BranchUpdateOptions,
   RequestOptions,
   UserDescriptor
 } from "../types";
@@ -134,6 +135,65 @@ export default class Branches extends Endpoint {
         ]);
 
         return wrap(response.data, response);
+      },
+
+      requestOptions
+    });
+  }
+
+  update(descriptor: BranchDescriptor, options: BranchUpdateOptions) {
+    const {
+      name,
+      description,
+      status,
+      canUseAbstractd = false,
+      ...requestOptions
+    } = options;
+
+    return this.configureRequest<Promise<Branch>>("update", {
+      api: async () => {
+        let requestUrl = `projects/${descriptor.projectId}/branches/${descriptor.branchId}`;
+
+        const response = await this.apiRequest(requestUrl, {
+          headers,
+          method: "PUT",
+          body: {
+            name,
+            description,
+            status
+          }
+        });
+
+        return wrap(response.data, response);
+      },
+
+      cli: async () => {
+        const args = [
+          "branches",
+          "update",
+          descriptor.branchId,
+          `--project-id=${descriptor.projectId}`
+        ];
+
+        if (name) {
+          args.push(`--name=${name}`);
+        }
+
+        if (status) {
+          args.push(`--status=${status}`);
+        }
+
+        if (description) {
+          args.push(`--description=${description}`);
+        }
+
+        if (canUseAbstractd) {
+          args.push(`--abstractd`);
+        }
+
+        const response = await this.cliRequest(args);
+
+        return wrap(response.branches, response);
       },
 
       requestOptions

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -193,7 +193,7 @@ export default class Branches extends Endpoint {
 
         const response = await this.cliRequest(args);
 
-        return wrap(response.branches, response);
+        return wrap(response.data, response);
       },
 
       requestOptions

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -8,7 +8,7 @@ import type {
   ListOptions,
   ProjectDescriptor,
   RequestOptions,
-  UpdatedBranch,
+  BranchInput,
   UserDescriptor,
   User
 } from "../types";
@@ -145,13 +145,13 @@ export default class Branches extends Endpoint {
 
   update(
     descriptor: BranchDescriptor,
-    branch: UpdatedBranch,
+    branchInput: BranchInput,
     options?: {
       ...RequestOptions,
       user?: User
     } = {}
   ) {
-    const { name, description, status } = branch;
+    const { name, description, status } = branchInput;
     const { user, ...requestOptions } = options;
 
     return this.configureRequest<Promise<Branch>>("update", {

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -142,13 +142,7 @@ export default class Branches extends Endpoint {
   }
 
   update(descriptor: BranchDescriptor, options: BranchUpdateOptions) {
-    const {
-      name,
-      description,
-      status,
-      canUseAbstractd = false,
-      ...requestOptions
-    } = options;
+    const { name, description, status, ...requestOptions } = options;
 
     return this.configureRequest<Promise<Branch>>("update", {
       api: async () => {
@@ -185,10 +179,6 @@ export default class Branches extends Endpoint {
 
         if (description) {
           args.push(`--description=${description}`);
-        }
-
-        if (canUseAbstractd) {
-          args.push(`--abstractd`);
         }
 
         const response = await this.cliRequest(args);

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -146,10 +146,10 @@ export default class Branches extends Endpoint {
   update(
     descriptor: BranchDescriptor,
     branch: UpdatedBranch,
-    options: {
+    options?: {
       ...RequestOptions,
       user?: User
-    }
+    } = {}
   ) {
     const { name, description, status } = branch;
     const { user, ...requestOptions } = options;

--- a/src/types.js
+++ b/src/types.js
@@ -814,7 +814,7 @@ export type BranchMergeState = {
   behind?: number
 };
 
-export type UpdatedBranch = {
+export type BranchInput = {
   name?: string,
   description?: string,
   status?: string

--- a/src/types.js
+++ b/src/types.js
@@ -133,8 +133,7 @@ export type BranchUpdateOptions = {
   ...RequestOptions,
   name?: string,
   description?: string,
-  status?: string,
-  canUseAbstractd?: boolean
+  status?: string
 };
 
 export type CollectionsListOptions = {

--- a/src/types.js
+++ b/src/types.js
@@ -129,6 +129,14 @@ export type RawProgressOptions = {
   onProgress?: ProgressCallback
 };
 
+export type BranchUpdateOptions = {
+  ...RequestOptions,
+  name?: string,
+  description?: string,
+  status?: string,
+  canUseAbstractd?: boolean
+};
+
 export type CollectionsListOptions = {
   ...ListOptions,
   branchStatus?: string,

--- a/src/types.js
+++ b/src/types.js
@@ -129,13 +129,6 @@ export type RawProgressOptions = {
   onProgress?: ProgressCallback
 };
 
-export type BranchUpdateOptions = {
-  ...RequestOptions,
-  name?: string,
-  description?: string,
-  status?: string
-};
-
 export type CollectionsListOptions = {
   ...ListOptions,
   branchStatus?: string,
@@ -819,6 +812,12 @@ export type BranchMergeState = {
   branchCommit?: string,
   ahead?: number,
   behind?: number
+};
+
+export type UpdatedBranch = {
+  name?: string,
+  description?: string,
+  status?: string
 };
 
 export type ChangesetStatus =

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -295,4 +295,97 @@ describe("branches", () => {
       });
     });
   });
+
+  describe("update", () => {
+    test("api - with new name attribute", async () => {
+      mockAPI(
+        "/projects/project-id/branches/branch-id",
+        {
+          data: {
+            branchId: "branch-id",
+            projectId: "project-id"
+          }
+        },
+        201,
+        "put"
+      );
+
+      const response = await API_CLIENT.branches.update(
+        {
+          branchId: "branch-id",
+          projectId: "project-id"
+        },
+        {
+          name: "branch-name"
+        }
+      );
+
+      expect(response).toEqual({
+        branchId: "branch-id",
+        projectId: "project-id"
+      });
+    });
+
+    test("api - with new name attribute", async () => {
+      mockAPI(
+        "/projects/project-id/branches/branch-id",
+        {
+          data: {
+            branchId: "branch-id",
+            projectId: "project-id"
+          }
+        },
+        201,
+        "put"
+      );
+
+      const response = await API_CLIENT.branches.update(
+        {
+          branchId: "branch-id",
+          projectId: "project-id"
+        },
+        {
+          status: "wip"
+        }
+      );
+
+      expect(response).toEqual({
+        branchId: "branch-id",
+        projectId: "project-id"
+      });
+    });
+
+    test("cli", async () => {
+      mockCLI(
+        [
+          "branches",
+          "update",
+          "branch-id",
+          "--project-id=project-id",
+          "--description=branch-description"
+        ],
+        {
+          data: {
+            branchId: "branch-id",
+            projectId: "project-id"
+          }
+        }
+      );
+
+      const response = await CLI_CLIENT.branches.update(
+        {
+          branchId: "branch-id",
+          projectId: "project-id"
+        },
+        {
+          description: "branch-description"
+        }
+      );
+
+      expect(response).toEqual({
+        branchId: "branch-id",
+        projectId: "project-id"
+      });
+    });
+  });
 });

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -347,6 +347,9 @@ describe("branches", () => {
         },
         {
           status: "wip"
+        },
+        {
+          transportMode: ["api"]
         }
       );
 
@@ -356,6 +359,18 @@ describe("branches", () => {
       });
     });
 
+    const user = {
+      id: "user-id",
+      name: "user-name",
+      avatarUrl: "user-avatar",
+      createdAt: "",
+      deletedAt: "",
+      lastActiveAt: "",
+      primaryEmailId: "user-email-id",
+      updatedAt: "",
+      username: "user-username"
+    };
+
     test("cli - with all attributes", async () => {
       mockCLI(
         [
@@ -363,6 +378,8 @@ describe("branches", () => {
           "update",
           "branch-id",
           "--project-id=project-id",
+          "--user-id=user-id",
+          "--user-name=user-name",
           "--name=branch-name",
           "--status=wip",
           "--description=branch-description"
@@ -384,6 +401,10 @@ describe("branches", () => {
           name: "branch-name",
           status: "wip",
           description: "branch-description"
+        },
+        {
+          transportMode: ["cli"],
+          user
         }
       );
 
@@ -394,19 +415,33 @@ describe("branches", () => {
     });
 
     test("cli - with no attributes", async () => {
-      mockCLI(["branches", "update", "branch-id", "--project-id=project-id"], {
-        data: {
-          branchId: "branch-id",
-          projectId: "project-id"
+      mockCLI(
+        [
+          "branches",
+          "update",
+          "branch-id",
+          "--project-id=project-id",
+          "--user-id=user-id",
+          "--user-name=user-name"
+        ],
+        {
+          data: {
+            branchId: "branch-id",
+            projectId: "project-id"
+          }
         }
-      });
+      );
 
       const response = await CLI_CLIENT.branches.update(
         {
           branchId: "branch-id",
           projectId: "project-id"
         },
-        {}
+        {},
+        {
+          transportMode: ["cli"],
+          user
+        }
       );
 
       expect(response).toEqual({

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -356,7 +356,7 @@ describe("branches", () => {
       });
     });
 
-    test("cli", async () => {
+    test("cli - with all attributes", async () => {
       mockCLI(
         [
           "branches",
@@ -385,6 +385,28 @@ describe("branches", () => {
           status: "wip",
           description: "branch-description"
         }
+      );
+
+      expect(response).toEqual({
+        branchId: "branch-id",
+        projectId: "project-id"
+      });
+    });
+
+    test("cli - with no attributes", async () => {
+      mockCLI(["branches", "update", "branch-id", "--project-id=project-id"], {
+        data: {
+          branchId: "branch-id",
+          projectId: "project-id"
+        }
+      });
+
+      const response = await CLI_CLIENT.branches.update(
+        {
+          branchId: "branch-id",
+          projectId: "project-id"
+        },
+        {}
       );
 
       expect(response).toEqual({

--- a/tests/endpoints/Branches.test.js
+++ b/tests/endpoints/Branches.test.js
@@ -316,7 +316,8 @@ describe("branches", () => {
           projectId: "project-id"
         },
         {
-          name: "branch-name"
+          name: "branch-name",
+          descripption: "branch-description"
         }
       );
 
@@ -326,7 +327,7 @@ describe("branches", () => {
       });
     });
 
-    test("api - with new name attribute", async () => {
+    test("api - with new status attribute", async () => {
       mockAPI(
         "/projects/project-id/branches/branch-id",
         {
@@ -362,6 +363,8 @@ describe("branches", () => {
           "update",
           "branch-id",
           "--project-id=project-id",
+          "--name=branch-name",
+          "--status=wip",
           "--description=branch-description"
         ],
         {
@@ -378,6 +381,8 @@ describe("branches", () => {
           projectId: "project-id"
         },
         {
+          name: "branch-name",
+          status: "wip",
           description: "branch-description"
         }
       );


### PR DESCRIPTION
To make web and desktop actions work seamlessly as it relates to updating branches ([ABS-2988](https://goabstract.atlassian.net/browse/ABS-2988)), we figured it was a good move to plumb an `update` method to our SDK now that we have the server-side api endpoint available.

This change will allow us to move the `BranchUpdateRequest` to core since we'll be able to perform this request from the SDK.