### PR TITLE
fix: Mark stream dependency as node-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "browser": {
     "@elasticprojects/abstract-cli": false,
     "child_process": false,
-    "fs": false
+    "fs": false,
+    "stream": false
   },
   "repository": "github:goabstract/abstract-sdk",
   "scripts": {


### PR DESCRIPTION
As suggested in comments of linked PR