### PR TITLE
chore(docs): remove links to deprecated spectrum community

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Complete SDK documentation can be found at [https://developer.abstract.com](http
 The following community resources are available to help you get started quickly with the SDK:
 
 - [Documentation website](https://developer.abstract.com)
-- [Spectrum chat](https://spectrum.chat/abstract)
 - [Abstract help center](https://www.abstract.com/help/)
 - [Abstract support](https://www.abstract.com/help/contact/)
 - Still stuck? [File an issue!](https://github.com/goabstract/abstract-sdk/issues/new)

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -20,8 +20,7 @@ const siteConfig = {
   organizationName: "goabstract",
   headerLinks: [
     { doc: "installation", label: "Getting started" },
-    { doc: "abstract-api", label: "API Reference" },
-    { href: "https://spectrum.chat/abstract/developers", label: "Community" }
+    { doc: "abstract-api", label: "API Reference" }
   ],
 
   gaTrackingId: "UA-102434873-3",


### PR DESCRIPTION
This updates the documentation to not reference a deprecated spectrum community. Now links won't direct you to a location we don't own or maintain.