### PR TITLE
fix: increase file export timeout for api transport

### DIFF
--- a/src/endpoints/Files.js
+++ b/src/endpoints/Files.js
@@ -11,8 +11,8 @@ import { FileExportError, NotFoundError } from "../errors";
 import { isNodeEnvironment, wrap } from "../util/helpers";
 import Endpoint from "../endpoints/Endpoint";
 
-const EXPORT_STATUS_CHECK_INTERVAL = 2000;
-const MAX_EXPORT_DURATION = EXPORT_STATUS_CHECK_INTERVAL * 15;
+const EXPORT_STATUS_CHECK_INTERVAL = 2000; // 2 seconds
+const MAX_EXPORT_DURATION = 1000 * 60 * 5; // 5 minutes
 
 export default class Files extends Endpoint {
   name = "files";

--- a/tests/endpoints/Files.test.js
+++ b/tests/endpoints/Files.test.js
@@ -203,7 +203,7 @@ describe("files", () => {
         ]
       });
 
-      [...Array(20)].forEach(() => {
+      [...Array(300)].forEach(() => {
         mockAPI(
           "/projects/project-id/branches/branch-id/files/file-id/export",
           {


### PR DESCRIPTION
Ran into an issue today where a file export was failing because it was taking ~45 seconds and for some reason there's a timeout imposed client-side for the `api` transport. I think we should be ok to increase this timeout or remove it altogether. I've increased it to 5 minutes in hopes to unblock a customer.