### PR TITLE
fix: Optional proxy agent param to fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [8.1.2](https://github.com/goabstract/abstract-sdk/compare/v8.1.2-0...v8.1.2) (2021-05-21)
+
 ### [8.1.2-0](https://github.com/goabstract/abstract-sdk/compare/v8.1.1...v8.1.2-0) (2021-05-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [8.1.2-0](https://github.com/goabstract/abstract-sdk/compare/v8.1.1...v8.1.2-0) (2021-05-17)
+
+
+### Bug Fixes
+
+* Pipe optional proxy agent param to fetch ([179246f](https://github.com/goabstract/abstract-sdk/commit/179246fe2ee7412e7cc2218dc1db0033ef75050d))
+
 ### [8.1.1](https://github.com/goabstract/abstract-sdk/compare/v8.1.0...v8.1.1) (2021-04-05)
 
 

--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -1,4 +1,5 @@
 // errors.js
+import http from "http";
 
 export class BaseError extends Error {}
 
@@ -1870,7 +1871,8 @@ type CommandOptions = {
   previewUrl: string | Promise<string>,
   shareId?: () => Promise<string | ShareDescriptor | ShareUrlDescriptor | void>,
   transportMode: ("api" | "cli")[],
-  webUrl: string | Promise<string>
+  webUrl: string | Promise<string>,
+  proxyAgent?: http.Agent
 };
 
 

--- a/abstract-sdk.d.ts
+++ b/abstract-sdk.d.ts
@@ -1,5 +1,5 @@
 // errors.js
-import http from "http";
+import { Agent } from "http";
 
 export class BaseError extends Error {}
 
@@ -1872,7 +1872,7 @@ type CommandOptions = {
   shareId?: () => Promise<string | ShareDescriptor | ShareUrlDescriptor | void>,
   transportMode: ("api" | "cli")[],
   webUrl: string | Promise<string>,
-  proxyAgent?: http.Agent
+  proxyAgent?: Agent
 };
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,3 +58,26 @@ See [Transports](/docs/transports) for more information.
 _Default value: `https://app.goabstract.com`_
 
 This option can be used to specify a custom URL for the Abstract web application. This is used by the [API transport](/docs/transports) when generating URLs that link to specific parts of the web application.
+
+### `proxyAgent`
+
+_Default value: `undefined`_
+
+This option can be used to specify a custom proxy configuration which will be used for routing API requests. We recommend using in conjunction with the [https-proxy-agent](https://www.npmjs.com/package/https-proxy-agent) module for most circumstances, which would need to be installed separately. Configuration looks like:
+
+
+```javascript
+const HttpsProxyAgent = require("https-proxy-agent");
+const Abstract = require("abstract-sdk");
+
+const proxyAgent = new HttpsProxyAgent("http://127.0.0.1:8080");
+
+// alternatively pass one of the common env variables…
+// const proxyAgent = new HttpsProxyAgent(process.env.HTTPS_PROXY);
+
+const client = new Abstract.Client({
+  proxyAgent,
+  accessToken,
+  ...etc
+});
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abstract-sdk",
-  "version": "8.1.2-0",
+  "version": "8.1.2",
   "description": "Universal JavaScript bindings for the Abstract API and CLI",
   "keywords": [
     "abstract",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abstract-sdk",
-  "version": "8.1.1",
+  "version": "8.1.2-0",
   "description": "Universal JavaScript bindings for the Abstract API and CLI",
   "keywords": [
     "abstract",

--- a/src/endpoints/Activities.js
+++ b/src/endpoints/Activities.js
@@ -1,5 +1,7 @@
 // @flow
 import querystring from "query-string";
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   Activity,
   ActivityDescriptor,
@@ -10,8 +12,6 @@ import type {
   ProjectDescriptor,
   RequestOptions
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 export default class Activities extends Endpoint {
   name = "activities";

--- a/src/endpoints/Assets.js
+++ b/src/endpoints/Assets.js
@@ -2,6 +2,7 @@
 import { promises as fs } from "fs";
 import querystring from "query-string";
 import { isNodeEnvironment, wrap } from "../util/helpers";
+import Endpoint from "../endpoints/Endpoint";
 import type {
   Asset,
   AssetDescriptor,
@@ -11,7 +12,6 @@ import type {
   RawOptions,
   RequestOptions
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
 
 export default class Assets extends Endpoint {
   name = "assets";

--- a/src/endpoints/Branches.js
+++ b/src/endpoints/Branches.js
@@ -1,6 +1,9 @@
 // @flow
 import invariant from "invariant";
 import querystring from "query-string";
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
+import { BranchSearchCLIError } from "../errors";
 import type {
   Branch,
   BranchDescriptor,
@@ -12,9 +15,6 @@ import type {
   UserDescriptor,
   User
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
-import { BranchSearchCLIError } from "../errors";
 
 // Version 17 returns policies for branches
 const headers = {

--- a/src/endpoints/Changesets.js
+++ b/src/endpoints/Changesets.js
@@ -1,4 +1,6 @@
 // @flow
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   ProjectDescriptor,
   BranchDescriptor,
@@ -6,8 +8,6 @@ import type {
   BranchCommitDescriptor,
   RequestOptions
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 const headers = {
   "Abstract-Api-Version": "19"

--- a/src/endpoints/CollectionLayers.js
+++ b/src/endpoints/CollectionLayers.js
@@ -1,4 +1,6 @@
 // @flow
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   CollectionDescriptor,
   CollectionLayer,
@@ -7,8 +9,6 @@ import type {
   RequestOptions,
   UpdatedCollectionLayer
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 export default class CollectionLayers extends Endpoint {
   name = "collectionLayers";

--- a/src/endpoints/Collections.js
+++ b/src/endpoints/Collections.js
@@ -1,5 +1,7 @@
 // @flow
 import querystring from "query-string";
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   BranchDescriptor,
   Collection,
@@ -10,8 +12,6 @@ import type {
   RequestOptions,
   UpdatedCollection
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 // Version 16 returns cached thumbnails
 const API_VERSION = 16;

--- a/src/endpoints/Comments.js
+++ b/src/endpoints/Comments.js
@@ -1,5 +1,7 @@
 // @flow
 import querystring from "query-string";
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   BranchDescriptor,
   Comment,
@@ -11,8 +13,6 @@ import type {
   PageDescriptor,
   RequestOptions
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 export default class Comments extends Endpoint {
   name = "comments";

--- a/src/endpoints/Commits.js
+++ b/src/endpoints/Commits.js
@@ -1,5 +1,7 @@
 // @flow
 import querystring from "query-string";
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   BranchDescriptor,
   Commit,
@@ -10,8 +12,6 @@ import type {
   LayerVersionDescriptor,
   RequestOptions
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 export default class Commits extends Endpoint {
   name = "commits";

--- a/src/endpoints/Data.js
+++ b/src/endpoints/Data.js
@@ -1,11 +1,11 @@
 // @flow
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   LayerDataset,
   LayerVersionDescriptor,
   RequestOptions
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 export default class Data extends Endpoint {
   name = "data";

--- a/src/endpoints/Descriptors.js
+++ b/src/endpoints/Descriptors.js
@@ -1,6 +1,6 @@
 // @flow
-import type { ObjectDescriptor, RequestOptions } from "../types";
 import Endpoint from "../endpoints/Endpoint";
+import type { ObjectDescriptor, RequestOptions } from "../types";
 
 export default class Descriptors extends Endpoint {
   async getLatestDescriptor<T: ObjectDescriptor>(

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -115,6 +115,8 @@ export default class Endpoint {
 
     fetchOptions.body = fetchOptions.body && JSON.stringify(fetchOptions.body);
     fetchOptions.headers = await this._getFetchHeaders(fetchOptions.headers);
+    fetchOptions.agent = this.options.proxyAgent;
+
     const args = [`${hostname}/${url}`, fetchOptions];
 
     /* istanbul ignore next */

--- a/src/endpoints/Files.js
+++ b/src/endpoints/Files.js
@@ -1,5 +1,8 @@
 // @flow
 import { promises as fs } from "fs";
+import { FileExportError, NotFoundError } from "../errors";
+import { isNodeEnvironment, wrap } from "../util/helpers";
+import Endpoint from "../endpoints/Endpoint";
 import type {
   BranchCommitDescriptor,
   File,
@@ -7,9 +10,6 @@ import type {
   RawProgressOptions,
   RequestOptions
 } from "../types";
-import { FileExportError, NotFoundError } from "../errors";
-import { isNodeEnvironment, wrap } from "../util/helpers";
-import Endpoint from "../endpoints/Endpoint";
 
 const EXPORT_STATUS_CHECK_INTERVAL = 2000; // 2 seconds
 const MAX_EXPORT_DURATION = 1000 * 60 * 5; // 5 minutes

--- a/src/endpoints/Layers.js
+++ b/src/endpoints/Layers.js
@@ -1,5 +1,7 @@
 // @flow
 import querystring from "query-string";
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   FileDescriptor,
   Layer,
@@ -8,8 +10,6 @@ import type {
   PageDescriptor,
   RequestOptions
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 type LayersListOptions = {
   ...ListOptions,

--- a/src/endpoints/Memberships.js
+++ b/src/endpoints/Memberships.js
@@ -1,4 +1,6 @@
 // @flow
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   Membership,
   OrganizationDescriptor,
@@ -7,8 +9,6 @@ import type {
   ProjectMembershipDescriptor,
   RequestOptions
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 export default class Memberships extends Endpoint {
   name = "memberships";

--- a/src/endpoints/Notifications.js
+++ b/src/endpoints/Notifications.js
@@ -1,5 +1,7 @@
 // @flow
 import querystring from "query-string";
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   ListOptions,
   Notification,
@@ -7,8 +9,6 @@ import type {
   OrganizationDescriptor,
   RequestOptions
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 export default class Notifications extends Endpoint {
   name = "notifications";

--- a/src/endpoints/Organizations.js
+++ b/src/endpoints/Organizations.js
@@ -1,11 +1,11 @@
 // @flow
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   OrganizationDescriptor,
   Organization,
   RequestOptions
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 // Version 27 does not return features for organizations
 const headers = {

--- a/src/endpoints/Pages.js
+++ b/src/endpoints/Pages.js
@@ -1,13 +1,13 @@
 // @flow
+import { NotFoundError } from "../errors";
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   FileDescriptor,
   Page,
   PageDescriptor,
   RequestOptions
 } from "../types";
-import { NotFoundError } from "../errors";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 export default class Pages extends Endpoint {
   name = "pages";

--- a/src/endpoints/Previews.js
+++ b/src/endpoints/Previews.js
@@ -2,14 +2,14 @@
 /* global Blob */
 import { promises as fs } from "fs";
 import { FileAPIError } from "../errors";
+import { isNodeEnvironment } from "../util/helpers";
+import Endpoint from "../endpoints/Endpoint";
 import type {
   LayerVersionDescriptor,
   PreviewMeta,
   RawOptions,
   RequestOptions
 } from "../types";
-import { isNodeEnvironment } from "../util/helpers";
-import Endpoint from "../endpoints/Endpoint";
 
 export default class Previews extends Endpoint {
   name = "previews";

--- a/src/endpoints/Projects.js
+++ b/src/endpoints/Projects.js
@@ -1,5 +1,7 @@
 // @flow
 import querystring from "query-string";
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   NewProject,
   OrganizationDescriptor,
@@ -7,8 +9,6 @@ import type {
   ProjectDescriptor,
   RequestOptions
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 const headers = {
   "Abstract-Api-Version": "22"

--- a/src/endpoints/ReviewRequests.js
+++ b/src/endpoints/ReviewRequests.js
@@ -1,4 +1,6 @@
 // @flow
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   BranchDescriptor,
   OrganizationDescriptor,
@@ -6,8 +8,6 @@ import type {
   RequestOptions,
   ReviewRequest
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 export default class ReviewRequests extends Endpoint {
   name = "reviewRequests";

--- a/src/endpoints/Sections.js
+++ b/src/endpoints/Sections.js
@@ -1,7 +1,7 @@
 // @flow
-import type { OrganizationDescriptor, RequestOptions, Section } from "../types";
 import Endpoint from "../endpoints/Endpoint";
 import { wrap } from "../util/helpers";
+import type { OrganizationDescriptor, RequestOptions, Section } from "../types";
 
 export default class Sections extends Endpoint {
   name = "sections";

--- a/src/endpoints/Shares.js
+++ b/src/endpoints/Shares.js
@@ -1,5 +1,6 @@
 // @flow
 import { inferShareId, wrap } from "../util/helpers";
+import Endpoint from "../endpoints/Endpoint";
 import type {
   OrganizationDescriptor,
   RequestOptions,
@@ -8,7 +9,6 @@ import type {
   ShareUrlDescriptor,
   ShareInput
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
 
 const headers = {
   "Abstract-Api-Version": "13"

--- a/src/endpoints/Stars.js
+++ b/src/endpoints/Stars.js
@@ -1,12 +1,12 @@
 // @flow
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   ProjectDescriptor,
   RequestOptions,
   SectionDescriptor,
   Star
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 export default class Stars extends Endpoint {
   name = "stars";

--- a/src/endpoints/Users.js
+++ b/src/endpoints/Users.js
@@ -1,4 +1,6 @@
 // @flow
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   OrganizationDescriptor,
   ProjectDescriptor,
@@ -6,8 +8,6 @@ import type {
   User,
   UserDescriptor
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 export default class Users extends Endpoint {
   name = "users";
@@ -39,7 +39,10 @@ export default class Users extends Endpoint {
         }
 
         const response = await this.apiRequest(url);
-        return wrap(response.data.map(membership => membership.user), response);
+        return wrap(
+          response.data.map(membership => membership.user),
+          response
+        );
       },
       requestOptions
     });

--- a/src/endpoints/Webhooks.js
+++ b/src/endpoints/Webhooks.js
@@ -1,5 +1,7 @@
 // @flow
 import sha256 from "js-sha256";
+import Endpoint from "../endpoints/Endpoint";
+import { wrap } from "../util/helpers";
 import type {
   NewWebhook,
   OrganizationDescriptor,
@@ -10,8 +12,6 @@ import type {
   WebhookDescriptor,
   WebhookEvent
 } from "../types";
-import Endpoint from "../endpoints/Endpoint";
-import { wrap } from "../util/helpers";
 
 export default class Users extends Endpoint {
   name = "webhooks";

--- a/src/types.js
+++ b/src/types.js
@@ -165,7 +165,7 @@ export type CommandOptions = {
   shareId?: () => Promise<string | ShareDescriptor | ShareUrlDescriptor | void>,
   transportMode: ("api" | "cli")[],
   webUrl: string | Promise<string>,
-  proxyAgent: ?http.Agent
+  proxyAgent?: http.Agent
 };
 
 export type Star = {

--- a/src/types.js
+++ b/src/types.js
@@ -1,5 +1,6 @@
 // @flow
 /* istanbul ignore file */
+import http from "http";
 
 export type OrganizationDescriptor = {|
   organizationId: string
@@ -163,7 +164,8 @@ export type CommandOptions = {
   previewUrl: string | Promise<string>,
   shareId?: () => Promise<string | ShareDescriptor | ShareUrlDescriptor | void>,
   transportMode: ("api" | "cli")[],
-  webUrl: string | Promise<string>
+  webUrl: string | Promise<string>,
+  proxyAgent: ?http.Agent
 };
 
 export type Star = {

--- a/src/types.js
+++ b/src/types.js
@@ -1,6 +1,6 @@
 // @flow
 /* istanbul ignore file */
-import http from "http";
+import { Agent } from "http";
 
 export type OrganizationDescriptor = {|
   organizationId: string
@@ -165,7 +165,7 @@ export type CommandOptions = {
   shareId?: () => Promise<string | ShareDescriptor | ShareUrlDescriptor | void>,
   transportMode: ("api" | "cli")[],
   webUrl: string | Promise<string>,
-  proxyAgent?: http.Agent
+  proxyAgent?: Agent
 };
 
 export type Star = {


### PR DESCRIPTION
I have tested locally with `mitmproxy` and it seems work great. I did think about using `node-proxy-fetch` instead to auto-detect proxy config but this suggestion from the issue I think is the most flexible and allows us to keep that configuration out of the actual module itself.

```javascript
const HttpsProxyAgent = require("https-proxy-agent");
const Abstract = require("abstract-sdk");

// change to point to your proxy or use env variable if available
const proxyAgent = new HttpsProxyAgent("http://127.0.0.1:8080");

const client = new Abstract.Client({
  proxyAgent,
  accessToken,
  ...etc
});
```

closes #328 