### PR TITLE
Fix: export files with / in their names

### DIFF
--- a/src/endpoints/Assets.js
+++ b/src/endpoints/Assets.js
@@ -103,7 +103,8 @@ export default class Assets extends Endpoint {
         /* istanbul ignore if */
         if (isNodeEnvironment() && !disableWrite) {
           const diskLocation =
-            filename || `${asset.layerName}.${asset.fileFormat}`;
+            filename ||
+            `${asset.layerName.replace(/\//g, "-")}.${asset.fileFormat}`;
           fs.writeFile(diskLocation, Buffer.from(arrayBuffer));
         }
 

--- a/src/endpoints/Files.js
+++ b/src/endpoints/Files.js
@@ -129,7 +129,8 @@ export default class Files extends Endpoint {
 
             /* istanbul ignore if */
             if (isNodeEnvironment() && !disableWrite) {
-              const diskLocation = filename || `${file.name}.sketch`;
+              const diskLocation =
+                filename || `${file.name.replace(/\//g, "-")}.sketch`;
               fs.writeFile(diskLocation, Buffer.from(arrayBuffer));
             }
 


### PR DESCRIPTION
this fixes the following crash in `files.raw` endpoint:

```
(node:75718) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, open '[FILE WITH / IN ITS NAME].sketch'
(Use `node --trace-warnings ...` to show where the warning was created)
(node:75718) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:75718) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```